### PR TITLE
Add death audio event listener

### DIFF
--- a/client/src/components/game/mechanics/eventListeners/addVisibilityDetection.js
+++ b/client/src/components/game/mechanics/eventListeners/addVisibilityDetection.js
@@ -7,6 +7,7 @@ export default function addVisibilityDetection(
   scaredTimer,
   retreatingTimers,
   ghostAudioObjects,
+  pacmanDeathAudio,
   callbackOne = pauseTimers,
   callbackTwo = resumeTimers
 ) {
@@ -18,9 +19,11 @@ export default function addVisibilityDetection(
         ghostAudioObjects[0].pause();
         ghostAudioObjects[1].pause();
         ghostAudioObjects[2].pause();
+        if (pacmanDeathAudio._state === "loaded") pacmanDeathAudio.pause();
         callbackOne(cycleTimer, scaredTimer, retreatingTimers);
       } else {
         variables.windowIsVisible = true;
+        if (pacmanDeathAudio._state === "loaded") pacmanDeathAudio.play();
         callbackTwo(cycleTimer, scaredTimer, retreatingTimers);
       }
     })

--- a/client/src/components/game/mechanics/eventListeners/addVisibilityDetection.test.js
+++ b/client/src/components/game/mechanics/eventListeners/addVisibilityDetection.test.js
@@ -8,6 +8,8 @@ let mockSirenAudio;
 let mockScaredAudio;
 let mockRetreatingAudio;
 let mockGhostAudioObjects;
+let mockPacmanDeathAudio;
+let mockUnloadedPacmanDeathAudio;
 let mockPauseTimers;
 let mockResumeTimers;
 let visibilityChange;
@@ -35,55 +37,192 @@ describe("addVisibilityDetection", () => {
       mockScaredAudio,
       mockRetreatingAudio,
     ];
+    mockPacmanDeathAudio = {
+      _state: "loaded",
+      pause: () => undefined,
+      play: () => undefined,
+    };
+    mockUnloadedPacmanDeathAudio = {
+      _state: "unloaded",
+      pause: () => undefined,
+      play: () => undefined,
+    };
     mockPauseTimers = jest.fn();
     mockResumeTimers = jest.fn();
     visibilityChange = new Event("visibilitychange");
+  });
+
+  it("sets visibilityEventListener in the variables object to the arrow function that defines the event listener", () => {
     addVisibilityDetection(
       mockVariables,
       mockCycleTimer,
       mockScaredTimer,
       mockRetreatingTimers,
       mockGhostAudioObjects,
+      mockPacmanDeathAudio,
       mockPauseTimers,
       mockResumeTimers
     );
-  });
-
-  it("sets visibilityEventListener in the variables object to the arrow function that defines the event listener", () => {
     expect(mockVariables.visibilityEventListener).toEqual(expect.any(Function));
   });
 
   describe("adds an event listener", () => {
     it("to change windowIsVisible to false if it is initially true", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
       mockVariables.windowIsVisible = true;
       document.dispatchEvent(visibilityChange);
       expect(mockVariables.windowIsVisible).toBeFalsy();
     });
 
     it("to change windowIsVisible to true if it is intially false", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
       document.dispatchEvent(visibilityChange);
       expect(mockVariables.windowIsVisible).toBeFalsy();
     });
 
     it("calls pause on the ghosts siren audio object if windowIsVisibly is initially true", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
       jest.spyOn(mockSirenAudio, "pause");
       document.dispatchEvent(visibilityChange);
       expect(mockSirenAudio.pause).toHaveBeenCalledTimes(1);
     });
 
     it("calls pause on the ghosts scared audio object if windowIsVisibly is initially true", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
       jest.spyOn(mockScaredAudio, "pause");
       document.dispatchEvent(visibilityChange);
       expect(mockScaredAudio.pause).toHaveBeenCalledTimes(1);
     });
 
-    it("calls pause on the ghosts retreating audio object if windowIsVisibly is initially true", () => {
+    it("calls pause on the ghosts retreating audio object if windowIsVisible is initially true", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
       jest.spyOn(mockRetreatingAudio, "pause");
       document.dispatchEvent(visibilityChange);
       expect(mockRetreatingAudio.pause).toHaveBeenCalledTimes(1);
     });
 
+    it("calls pause on the pacman death audio if it is loaded and windowIsVisible is initially true", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
+      jest.spyOn(mockPacmanDeathAudio, "pause");
+      document.dispatchEvent(visibilityChange);
+      expect(mockPacmanDeathAudio.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call pause on the pacman death audio if it is unloaded and windowIsVisible is initially true", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockUnloadedPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
+      jest.spyOn(mockUnloadedPacmanDeathAudio, "pause");
+      document.dispatchEvent(visibilityChange);
+      expect(mockUnloadedPacmanDeathAudio.pause).toHaveBeenCalledTimes(0);
+    });
+
+    it("calls play on the pacman death audio if it is loaded and windowIsVisible is initially false", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
+      mockVariables.windowIsVisible = false;
+      jest.spyOn(mockPacmanDeathAudio, "play");
+      document.dispatchEvent(visibilityChange);
+      expect(mockPacmanDeathAudio.play).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call play on the pacman death audio if it is unloaded and windowIsVisible is initially false", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockUnloadedPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
+      mockVariables.windowIsVisible = false;
+      jest.spyOn(mockUnloadedPacmanDeathAudio, "play");
+      document.dispatchEvent(visibilityChange);
+      expect(mockUnloadedPacmanDeathAudio.play).toHaveBeenCalledTimes(0);
+    });
+
     it("to call pauseTimers if windowIsVisible is intially true", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
       document.dispatchEvent(visibilityChange);
       expect(mockPauseTimers).toHaveBeenCalledTimes(1);
       expect(mockPauseTimers).toHaveBeenCalledWith(
@@ -94,6 +233,16 @@ describe("addVisibilityDetection", () => {
     });
 
     it("to call resumeTimers if windowIsVisible is intially false", () => {
+      addVisibilityDetection(
+        mockVariables,
+        mockCycleTimer,
+        mockScaredTimer,
+        mockRetreatingTimers,
+        mockGhostAudioObjects,
+        mockPacmanDeathAudio,
+        mockPauseTimers,
+        mockResumeTimers
+      );
       mockVariables.windowIsVisible = false;
       document.dispatchEvent(visibilityChange);
       expect(mockResumeTimers).toHaveBeenCalledTimes(1);

--- a/client/src/components/game/mechanics/finishSetup.js
+++ b/client/src/components/game/mechanics/finishSetup.js
@@ -22,10 +22,11 @@ export default function finishSetup(
     cycleTimer,
     scaredTimer,
     retreatingTimers,
-    ghostAudioObjects
+    ghostAudioObjects,
+    pacmanDeathAudio
   );
   variables.start = false;
   ghostAudioObjects.forEach((audio) => audio.load());
   ghostAudioObjects[0].play();
-  pacmanDeathAudio.load();
+  pacmanDeathAudio.unload();
 }

--- a/client/src/components/game/mechanics/finishSetup.test.js
+++ b/client/src/components/game/mechanics/finishSetup.test.js
@@ -47,7 +47,7 @@ describe("finishSetup", () => {
       mockRetreatingAudio,
     ];
     mockPacmanDeathAudio = {
-      load: () => undefined,
+      unload: () => undefined,
     };
     mockAddDirectionDetection = jest.fn();
     mockAddVisibilityDetection = jest.fn();
@@ -124,7 +124,8 @@ describe("finishSetup", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockRetreatingTimers,
-      mockGhostAudioObjects
+      mockGhostAudioObjects,
+      mockPacmanDeathAudio
     );
   });
 
@@ -198,7 +199,7 @@ describe("finishSetup", () => {
   });
 
   it("loads the Pac-Man death audio", () => {
-    jest.spyOn(mockPacmanDeathAudio, "load");
+    jest.spyOn(mockPacmanDeathAudio, "unload");
     finishSetup(
       mockVariables,
       mockName,
@@ -211,6 +212,6 @@ describe("finishSetup", () => {
       mockAddDirectionDetection,
       mockAddVisibilityDetection
     );
-    expect(mockPacmanDeathAudio.load).toHaveBeenCalledTimes(1);
+    expect(mockPacmanDeathAudio.unload).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.js
@@ -19,6 +19,7 @@ export default function dealWithCollision(
     pacman.radians = Math.PI / 4;
     cancelAnimationFrame(variables.animationId);
     ghostAudioObjects.forEach((audio) => audio.unload());
+    pacmanDeathAudio.load();
     pacmanDeathAudio.play();
     callback(
       variables,

--- a/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.test.js
@@ -64,6 +64,7 @@ describe("dealWithCollision", () => {
     mockCtx = "ctx";
     mockBoundaries = "boundaries";
     mockPacmanDeathAudio = {
+      load: () => undefined,
       play: () => undefined,
     };
     mockRunDeathAnimation = jest.fn();
@@ -138,7 +139,8 @@ describe("dealWithCollision", () => {
     expect(mockRetreatingAudio.unload).toHaveBeenCalledTimes(1);
   });
 
-  it("calls play on the pacmanDeathAudio", () => {
+  it("calls load and play on the pacmanDeathAudio", () => {
+    jest.spyOn(mockPacmanDeathAudio, "load");
     jest.spyOn(mockPacmanDeathAudio, "play");
     dealWithCollision(
       mockGhost,
@@ -155,6 +157,7 @@ describe("dealWithCollision", () => {
       mockPacmanDeathAudio,
       mockRunDeathAnimation
     );
+    expect(mockPacmanDeathAudio.load).toHaveBeenCalledTimes(1);
     expect(mockPacmanDeathAudio.play).toHaveBeenCalledTimes(1);
   });
 

--- a/client/src/components/game/mechanics/ghosts/collisions/endGame.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/endGame.js
@@ -10,7 +10,6 @@ export default async function endGame(
   pacman,
   cycleTimer,
   scaredTimer,
-  pacmanDeathAudio,
   callbackOne = saveScore,
   callbackTwo = resetAfterGameOver
 ) {
@@ -23,8 +22,7 @@ export default async function endGame(
     pacman,
     variables,
     cycleTimer,
-    scaredTimer,
-    pacmanDeathAudio
+    scaredTimer
   );
   variables.reactRoot.render(<Leaderboard variables={variables} />);
 }

--- a/client/src/components/game/mechanics/ghosts/collisions/endGame.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/endGame.test.js
@@ -10,7 +10,6 @@ let mockGhosts;
 let mockPacman;
 let mockCycleTimer;
 let mockScaredTimer;
-let mockPacmanDeathAudio;
 let mockSaveScore;
 let mockResetAfterGameOver;
 
@@ -29,7 +28,6 @@ describe("endGame", () => {
     mockPacman = "pacman";
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
-    mockPacmanDeathAudio = "mockPacmanDeathAudio";
     mockSaveScore = jest.fn();
     mockResetAfterGameOver = jest.fn();
     jest.spyOn(mockVariables.reactRoot, "render");
@@ -45,7 +43,6 @@ describe("endGame", () => {
       mockPacman,
       mockCycleTimer,
       mockScaredTimer,
-      mockPacmanDeathAudio,
       mockSaveScore,
       mockResetAfterGameOver
     );
@@ -64,7 +61,6 @@ describe("endGame", () => {
       mockPacman,
       mockCycleTimer,
       mockScaredTimer,
-      mockPacmanDeathAudio,
       mockSaveScore,
       mockResetAfterGameOver
     );
@@ -81,7 +77,6 @@ describe("endGame", () => {
       mockPacman,
       mockCycleTimer,
       mockScaredTimer,
-      mockPacmanDeathAudio,
       mockSaveScore,
       mockResetAfterGameOver
     );
@@ -93,8 +88,7 @@ describe("endGame", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
   });
 
@@ -107,7 +101,6 @@ describe("endGame", () => {
       mockPacman,
       mockCycleTimer,
       mockScaredTimer,
-      mockPacmanDeathAudio,
       mockSaveScore,
       mockResetAfterGameOver
     );

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeathAnimation/checkPacmanLives.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeathAnimation/checkPacmanLives.js
@@ -10,7 +10,6 @@ export default function checkPacmanLives(
   cycleTimer,
   scaredTimer,
   ghostAudioObjects,
-  pacmanDeathAudio,
   callbackOne = endGame,
   callbackTwo = resetAfterDeath
 ) {
@@ -22,8 +21,7 @@ export default function checkPacmanLives(
       ghosts,
       pacman,
       cycleTimer,
-      scaredTimer,
-      pacmanDeathAudio
+      scaredTimer
     );
   } else {
     pacman.lives--;

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeathAnimation/checkPacmanLives.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeathAnimation/checkPacmanLives.test.js
@@ -9,7 +9,6 @@ let mockPowerUps;
 let mockCycleTimer;
 let mockScaredTimer;
 let mockGhostAudioObjects;
-let mockPacmanDeathAudio;
 let mockEndGame;
 let mockResetAfterDeath;
 
@@ -28,7 +27,6 @@ describe("checkPacmanLives", () => {
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
     mockGhostAudioObjects = "ghostAudioObjects";
-    mockPacmanDeathAudio = "PacmanDeathAudio";
     mockEndGame = jest.fn();
     mockResetAfterDeath = jest.fn();
   });
@@ -43,7 +41,6 @@ describe("checkPacmanLives", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockGhostAudioObjects,
-      mockPacmanDeathAudio,
       mockEndGame,
       mockResetAfterDeath
     );
@@ -55,8 +52,7 @@ describe("checkPacmanLives", () => {
       mockGhosts,
       mockNoLivesPacman,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
   });
 
@@ -70,7 +66,6 @@ describe("checkPacmanLives", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockGhostAudioObjects,
-      mockPacmanDeathAudio,
       mockEndGame,
       mockResetAfterDeath
     );
@@ -87,7 +82,6 @@ describe("checkPacmanLives", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockGhostAudioObjects,
-      mockPacmanDeathAudio,
       mockEndGame,
       mockResetAfterDeath
     );

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeathAnimation/runDeathAnimation.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeathAnimation/runDeathAnimation.js
@@ -37,6 +37,7 @@ export default function runDeathAnimation(
     pacman.shrink(ctx);
   } else {
     cancelAnimationFrame(variables.animationId);
+    pacmanDeathAudio.unload();
     callbackThree(
       pacman,
       variables,
@@ -45,8 +46,7 @@ export default function runDeathAnimation(
       ghosts,
       cycleTimer,
       scaredTimer,
-      ghostAudioObjects,
-      pacmanDeathAudio
+      ghostAudioObjects
     );
   }
 }

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeathAnimation/runDeathAnimation.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeathAnimation/runDeathAnimation.test.js
@@ -39,7 +39,9 @@ describe("runDeathAnimation", () => {
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
     mockGhostAudioObjects = "ghostAudioObjects";
-    mockPacmanDeathAudio = "PacmanDeathAudio";
+    mockPacmanDeathAudio = {
+      unload: () => undefined,
+    };
     mockRunDeathAnimation = jest.fn();
     mockDrawBoard = jest.fn();
     mockCheckPacmanLives = jest.fn();
@@ -154,6 +156,27 @@ describe("runDeathAnimation", () => {
     );
   });
 
+  it("calls unload on the death audio when Pac-Man's death animation has finished", () => {
+    jest.spyOn(mockPacmanDeathAudio, "unload");
+    runDeathAnimation(
+      mockVariables,
+      mockCtx,
+      mockBoundaries,
+      mockPellets,
+      mockPowerUps,
+      mockShrunkPacman,
+      mockGhosts,
+      mockCycleTimer,
+      mockScaredTimer,
+      mockGhostAudioObjects,
+      mockPacmanDeathAudio,
+      mockRunDeathAnimation,
+      mockDrawBoard,
+      mockCheckPacmanLives
+    );
+    expect(mockPacmanDeathAudio.unload).toHaveBeenCalledTimes(1);
+  });
+
   it("calls checkPacmanLives when Pac-Man's death animation has finished", () => {
     runDeathAnimation(
       mockVariables,
@@ -180,8 +203,7 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockGhostAudioObjects,
-      mockPacmanDeathAudio
+      mockGhostAudioObjects
     );
   });
 });

--- a/client/src/components/game/mechanics/ghosts/collisions/resetAfterGameOver.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/resetAfterGameOver.js
@@ -5,8 +5,7 @@ export default function resetAfterGameOver(
   pacman,
   variables,
   cycleTimer,
-  scaredTimer,
-  pacmanDeathAudio
+  scaredTimer
 ) {
   pellets.forEach((pellet) => {
     if (pellet.hasBeenEaten) pellet.changeEatenState();
@@ -28,5 +27,4 @@ export default function resetAfterGameOver(
     "visibilitychange",
     variables.visibilityEventListener
   );
-  pacmanDeathAudio.unload();
 }

--- a/client/src/components/game/mechanics/ghosts/collisions/resetAfterGameOver.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/resetAfterGameOver.test.js
@@ -14,7 +14,6 @@ let mockPacman;
 let mockVariables;
 let mockCycleTimer;
 let mockScaredTimer;
-let mockPacmanDeathAudio;
 
 describe("resetAfterGameOver", () => {
   beforeEach(() => {
@@ -62,9 +61,6 @@ describe("resetAfterGameOver", () => {
     mockScaredTimer = {
       reset: () => undefined,
     };
-    mockPacmanDeathAudio = {
-      unload: () => undefined,
-    };
   });
 
   it("calls changeEatenState on the pellets if they have been eaten", () => {
@@ -76,8 +72,7 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockEatenPellet.changeEatenState).toHaveBeenCalledTimes(3);
   });
@@ -91,8 +86,7 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockUneatenPellet.changeEatenState).toHaveBeenCalledTimes(0);
   });
@@ -106,8 +100,7 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockEatenPowerUp.changeEatenState).toHaveBeenCalledTimes(2);
   });
@@ -121,8 +114,7 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockUneatenPowerUp.changeEatenState).toHaveBeenCalledTimes(0);
   });
@@ -136,8 +128,7 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockCycleTimer.reset).toHaveBeenCalledTimes(1);
   });
@@ -151,8 +142,7 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockScaredTimer.reset).toHaveBeenCalledTimes(1);
   });
@@ -166,8 +156,7 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockGhost.reset).toHaveBeenCalledTimes(2);
   });
@@ -181,8 +170,7 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockPacman.reset).toHaveBeenCalledTimes(1);
   });
@@ -195,8 +183,7 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockPacman.lives).toBe(2);
   });
@@ -209,8 +196,7 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockVariables.lastKeyPressed).toBe("");
   });
@@ -223,24 +209,8 @@ describe("resetAfterGameOver", () => {
       mockPacman,
       mockVariables,
       mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
+      mockScaredTimer
     );
     expect(mockVariables.level).toBe(1);
-  });
-
-  it("unloads the pacman death audio", () => {
-    jest.spyOn(mockPacmanDeathAudio, "unload");
-    resetAfterGameOver(
-      mockEatenPellets,
-      mockEatenPowerUps,
-      mockGhosts,
-      mockPacman,
-      mockVariables,
-      mockCycleTimer,
-      mockScaredTimer,
-      mockPacmanDeathAudio
-    );
-    expect(mockPacmanDeathAudio.unload).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Pause and play the Pac-Man death audio when a visibility change occurs only
if the audio state is loaded. Therefore, unload the audio object on setup
and only load it when Pac-Man collides with a normal ghost. Then, immediately
after the Pac-Man death animation has finished, unload it again.