### PR TITLE
Model tests

### DIFF
--- a/client/src/components/game/models/boundary.test.js
+++ b/client/src/components/game/models/boundary.test.js
@@ -26,14 +26,14 @@ describe("Boundary", () => {
       expect(boundary.height).toBe(20);
     });
 
-    it("has a position that is passed in on instantiation", () => {
+    it("has a position that is passed in", () => {
       expect(boundary.position).toEqual({
         x: 40,
         y: 100,
       });
     });
 
-    it("has an image that is passed in on instantiation", () => {
+    it("has an image that is passed in", () => {
       expect(boundary.image).toEqual({
         src: "./randomSource",
       });
@@ -48,6 +48,7 @@ describe("Boundary", () => {
       jest.spyOn(mockCtx, "drawImage");
       boundary.draw(mockCtx);
       expect(mockCtx.drawImage).toHaveBeenCalledTimes(1);
+      expect(mockCtx.drawImage).toHaveBeenCalledWith(mockImage, 40, 100);
     });
   });
 });

--- a/client/src/components/game/models/ghost.test.js
+++ b/client/src/components/game/models/ghost.test.js
@@ -104,6 +104,7 @@ describe("Ghost", () => {
       jest.spyOn(mockCtx, "drawImage");
       ghost.draw(mockCtx);
       expect(mockCtx.drawImage).toHaveBeenCalledTimes(1);
+      expect(mockCtx.drawImage).toHaveBeenCalledWith(ghost.image, 5, 5);
     });
   });
 
@@ -114,6 +115,7 @@ describe("Ghost", () => {
       ghost.update(mockCtx);
       expect(ghost.assignSprite).toHaveBeenCalledTimes(1);
       expect(ghost.draw).toHaveBeenCalledTimes(1);
+      expect(ghost.draw).toHaveBeenCalledWith(mockCtx);
       expect(ghost.position).toEqual({
         x: 27.5,
         y: 22.5,

--- a/client/src/components/game/models/pacman.test.js
+++ b/client/src/components/game/models/pacman.test.js
@@ -98,14 +98,25 @@ describe("PacMan", () => {
       pacman.draw(mockCtx);
       expect(mockCtx.save).toHaveBeenCalledTimes(1);
       expect(mockCtx.translate).toHaveBeenCalledTimes(2);
+      expect(mockCtx.translate).toHaveBeenNthCalledWith(1, 290, 470);
+      expect(mockCtx.translate).toHaveBeenNthCalledWith(2, -290, -470);
       expect(mockCtx.rotate).toHaveBeenCalledTimes(1);
+      expect(mockCtx.rotate).toHaveBeenCalledWith(0);
       expect(mockCtx.beginPath).toHaveBeenCalledTimes(1);
       expect(mockCtx.arc).toHaveBeenCalledTimes(1);
+      expect(mockCtx.arc).toHaveBeenCalledWith(
+        290,
+        470,
+        15,
+        Math.PI / 4,
+        (7 * Math.PI) / 4
+      );
       expect(mockCtx.lineTo).toHaveBeenCalledTimes(1);
+      expect(mockCtx.lineTo).toHaveBeenCalledWith(285, 470);
+      expect(mockCtx.fillStyle).toBe("yellow");
       expect(mockCtx.fill).toHaveBeenCalledTimes(1);
       expect(mockCtx.closePath).toHaveBeenCalledTimes(1);
       expect(mockCtx.restore).toHaveBeenCalledTimes(1);
-      expect(mockCtx.fillStyle).toBe("yellow");
     });
   });
 
@@ -116,6 +127,7 @@ describe("PacMan", () => {
       pacman.update(mockCtx);
       expect(pacman.checkRotation).toHaveBeenCalledTimes(1);
       expect(pacman.draw).toHaveBeenCalledTimes(1);
+      expect(pacman.draw).toHaveBeenCalledWith(mockCtx);
       expect(pacman.position).toEqual({
         x: 297.5,
         y: 472.5,

--- a/client/src/components/game/models/pellet.test.js
+++ b/client/src/components/game/models/pellet.test.js
@@ -65,9 +65,10 @@ describe("Pellet", () => {
       pellet.draw(mockCtx);
       expect(mockCtx.beginPath).toHaveBeenCalledTimes(1);
       expect(mockCtx.arc).toHaveBeenCalledTimes(1);
+      expect(mockCtx.arc).toHaveBeenCalledWith(50, 100, 2, 0, Math.PI * 2);
+      expect(mockCtx.fillStyle).toBe("white");
       expect(mockCtx.fill).toHaveBeenCalledTimes(1);
       expect(mockCtx.closePath).toHaveBeenCalledTimes(1);
-      expect(mockCtx.fillStyle).toBe("white");
     });
   });
 });

--- a/client/src/components/game/models/powerUp.test.js
+++ b/client/src/components/game/models/powerUp.test.js
@@ -65,6 +65,7 @@ describe("PowerUp", () => {
       jest.spyOn(powerUp, "flash");
       powerUp.update(mockCtx);
       expect(powerUp.draw).toHaveBeenCalledTimes(1);
+      expect(powerUp.draw).toHaveBeenCalledWith(mockCtx);
       expect(powerUp.flash).toHaveBeenCalledTimes(1);
     });
   });
@@ -78,9 +79,10 @@ describe("PowerUp", () => {
       powerUp.draw(mockCtx);
       expect(mockCtx.beginPath).toHaveBeenCalledTimes(1);
       expect(mockCtx.arc).toHaveBeenCalledTimes(1);
+      expect(mockCtx.arc).toHaveBeenCalledWith(50, 100, 7, 0, Math.PI * 2);
+      expect(mockCtx.fillStyle).toBe("white");
       expect(mockCtx.fill).toHaveBeenCalledTimes(1);
       expect(mockCtx.closePath).toHaveBeenCalledTimes(1);
-      expect(mockCtx.fillStyle).toBe("white");
     });
   });
 


### PR DESCRIPTION
Update the old model tests to the latest standard. Namely, check that certain functions are being called with the correct arguments, rather than just checking the number of times they are being called.