### PR TITLE
Make separate white boundary image

### DIFF
--- a/client/src/components/game/mechanics/boundaries/makeBoundaries.js
+++ b/client/src/components/game/mechanics/boundaries/makeBoundaries.js
@@ -10,85 +10,103 @@ export default function makeBoundaries(
   map.forEach((row, i) => {
     row.forEach((element, j) => {
       if (element === "-") {
-        const image = new Image();
-        image.src = "./images/pipeHorizontal.png";
+        const regularImage = new Image();
+        regularImage.src = "./images/pipeHorizontal.png";
+        const whiteImage = new Image();
+        whiteImage.src = "./images/pipeHorizontalWhite.png";
         const boundary = new Boundary(
           {
             position: {
               x: variables.tileLength * j,
               y: variables.tileLength * i,
             },
-            image: image,
+            regularImage: regularImage,
+            whiteImage: whiteImage,
           },
           variables.tileLength
         );
         boundaries.push(boundary);
       } else if (element === "|") {
-        const image = new Image();
-        image.src = "./images/pipeVertical.png";
+        const regularImage = new Image();
+        regularImage.src = "./images/pipeVertical.png";
+        const whiteImage = new Image();
+        whiteImage.src = "./images/pipeVerticalWhite.png";
         const boundary = new Boundary(
           {
             position: {
               x: variables.tileLength * j,
               y: variables.tileLength * i,
             },
-            image: image,
+            regularImage: regularImage,
+            whiteImage: whiteImage,
           },
           variables.tileLength
         );
         boundaries.push(boundary);
       } else if (element === "1") {
-        const image = new Image();
-        image.src = "./images/pipeCornerOne.png";
+        const regularImage = new Image();
+        regularImage.src = "./images/pipeCornerOne.png";
+        const whiteImage = new Image();
+        whiteImage.src = "./images/pipeCornerOneWhite.png";
         const boundary = new Boundary(
           {
             position: {
               x: variables.tileLength * j,
               y: variables.tileLength * i,
             },
-            image: image,
+            regularImage: regularImage,
+            whiteImage: whiteImage,
           },
           variables.tileLength
         );
         boundaries.push(boundary);
       } else if (element === "2") {
-        const image = new Image();
-        image.src = "./images/pipeCornerTwo.png";
+        const regularImage = new Image();
+        regularImage.src = "./images/pipeCornerTwo.png";
+        const whiteImage = new Image();
+        whiteImage.src = "./images/pipeCornerTwoWhite.png";
         const boundary = new Boundary(
           {
             position: {
               x: variables.tileLength * j,
               y: variables.tileLength * i,
             },
-            image: image,
+            regularImage: regularImage,
+            whiteImage: whiteImage,
           },
           variables.tileLength
         );
         boundaries.push(boundary);
       } else if (element === "3") {
-        const image = new Image();
-        image.src = "./images/pipeCornerThree.png";
+        const regularImage = new Image();
+        regularImage.src = "./images/pipeCornerThree.png";
+        const whiteImage = new Image();
+        whiteImage.src = "./images/pipeCornerThreeWhite.png";
         const boundary = new Boundary(
           {
             position: {
               x: variables.tileLength * j,
               y: variables.tileLength * i,
             },
-            image: image,
+            regularImage: regularImage,
+            whiteImage: whiteImage,
           },
           variables.tileLength
         );
         boundaries.push(boundary);
       } else if (element === "4") {
-        const image = new Image();
-        image.src = "./images/pipeCornerFour.png";
+        const regularImage = new Image();
+        regularImage.src = "./images/pipeCornerFour.png";
+        const whiteImage = new Image();
+        whiteImage.src = "./images/pipeCornerFourWhite.png";
         const boundary = new Boundary(
           {
             position: {
               x: variables.tileLength * j,
               y: variables.tileLength * i,
             },
-            image: image,
+            regularImage: regularImage,
+            whiteImage: whiteImage,
           },
           variables.tileLength
         );

--- a/client/src/components/game/mechanics/boundaries/makeTunnelBoundaries.js
+++ b/client/src/components/game/mechanics/boundaries/makeTunnelBoundaries.js
@@ -1,7 +1,9 @@
 import Boundary from "../../models/boundary";
 
-const image = new Image();
-image.src = "./images/pipeHorizontal.png";
+const regularImage = new Image();
+regularImage.src = "./images/pipeHorizontal.png";
+const whiteImage = new Image();
+whiteImage.src = "./images/pipeHorizontalWhite.png";
 
 export default function makeTunnelBoundaries(boundaries, variables) {
   const tunnelBoundaryOne = new Boundary(
@@ -10,7 +12,8 @@ export default function makeTunnelBoundaries(boundaries, variables) {
         x: -variables.tileLength,
         y: variables.tileLength * 13,
       },
-      image: image,
+      regularImage: regularImage,
+      whiteImage: whiteImage,
     },
     variables.tileLength
   );
@@ -20,7 +23,8 @@ export default function makeTunnelBoundaries(boundaries, variables) {
         x: -variables.tileLength,
         y: variables.tileLength * 15,
       },
-      image: image,
+      regularImage: regularImage,
+      whiteImage: whiteImage,
     },
     variables.tileLength
   );
@@ -30,7 +34,8 @@ export default function makeTunnelBoundaries(boundaries, variables) {
         x: variables.tileLength * 28,
         y: variables.tileLength * 13,
       },
-      image: image,
+      regularImage: regularImage,
+      whiteImage: whiteImage,
     },
     variables.tileLength
   );
@@ -40,7 +45,8 @@ export default function makeTunnelBoundaries(boundaries, variables) {
         x: variables.tileLength * 28,
         y: variables.tileLength * 15,
       },
-      image: image,
+      regularImage: regularImage,
+      whiteImage: whiteImage,
     },
     variables.tileLength
   );

--- a/client/src/components/game/models/boundary.js
+++ b/client/src/components/game/models/boundary.js
@@ -1,9 +1,11 @@
 export default class Boundary {
-  constructor({ position, image }, tileLength) {
+  constructor({ position, regularImage, whiteImage }, tileLength) {
     this.position = position;
     this.width = tileLength;
     this.height = tileLength;
-    this.image = image;
+    this.regularImage = regularImage;
+    this.whiteImage = whiteImage;
+    this.image = regularImage;
   }
 
   draw(ctx) {
@@ -12,8 +14,8 @@ export default class Boundary {
 
   flash() {
     let imageSource = this.image.src;
-    this.image.src = imageSource.includes("White")
-      ? imageSource.replace("White", "")
-      : imageSource.replace(".png", "White.png");
+    this.image = imageSource.includes("White")
+      ? this.regularImage
+      : this.whiteImage;
   }
 }

--- a/client/src/components/game/models/boundary.test.js
+++ b/client/src/components/game/models/boundary.test.js
@@ -1,12 +1,16 @@
 import Boundary from "./boundary";
 
 let boundary;
-let mockImage;
+let mockRegularImage;
+let mockWhiteImage;
 
 describe("Boundary", () => {
   beforeEach(() => {
-    mockImage = {
+    mockRegularImage = {
       src: "./randomSource.png",
+    };
+    mockWhiteImage = {
+      src: "./randomSourceWhite.png",
     };
     boundary = new Boundary(
       {
@@ -14,7 +18,8 @@ describe("Boundary", () => {
           x: 40,
           y: 100,
         },
-        image: mockImage,
+        regularImage: mockRegularImage,
+        whiteImage: mockWhiteImage,
       },
       20
     );
@@ -33,7 +38,19 @@ describe("Boundary", () => {
       });
     });
 
-    it("has an image that is passed in", () => {
+    it("has a regular image that is passed in", () => {
+      expect(boundary.regularImage).toEqual({
+        src: "./randomSource.png",
+      });
+    });
+
+    it("has a white image that is passed in", () => {
+      expect(boundary.whiteImage).toEqual({
+        src: "./randomSourceWhite.png",
+      });
+    });
+
+    it("has an image variable that is initially set to the regular image", () => {
       expect(boundary.image).toEqual({
         src: "./randomSource.png",
       });
@@ -48,20 +65,17 @@ describe("Boundary", () => {
       jest.spyOn(mockCtx, "drawImage");
       boundary.draw(mockCtx);
       expect(mockCtx.drawImage).toHaveBeenCalledTimes(1);
-      expect(mockCtx.drawImage).toHaveBeenCalledWith(mockImage, 40, 100);
+      expect(mockCtx.drawImage).toHaveBeenCalledWith(boundary.image, 40, 100);
     });
   });
 
   describe("flash", () => {
-    it("changes the image source from the regular to the white", () => {
+    it("switches the image source between regular and white", () => {
       boundary.flash();
-      expect(boundary.image.src).toBe("./randomSourceWhite.png");
-    });
+      expect(boundary.image).toEqual(boundary.whiteImage);
 
-    it("changes the image source from the white to the regular", () => {
-      mockImage.src = "./randomSourceWhite.png";
       boundary.flash();
-      expect(boundary.image.src).toBe("./randomSource.png");
+      expect(boundary.image).toEqual(boundary.regularImage);
     });
   });
 });


### PR DESCRIPTION
Create a new constructor variable in the Boundary class that will contain a separate image object for the white boundary images. This should avoid any flickering when the level up animation starts.