### PR TITLE
Audio management

### DIFF
--- a/client/src/components/game/mechanics/audio/manageGhostAudio.js
+++ b/client/src/components/game/mechanics/audio/manageGhostAudio.js
@@ -1,19 +1,11 @@
+import playGhostAudio from "./playGhostAudio";
+
 export default function manageGhostAudio(
   audioPlayer,
   scaredTimer,
-  retreatingTimers
+  retreatingTimers,
+  callback = playGhostAudio
 ) {
-  let count = 0;
-  retreatingTimers.forEach((timer) => {
-    if (timer.isRunning) count++;
-  });
-  if (count > 0) {
-    if (!audioPlayer.ghostRetreating.playing()) {
-      audioPlayer.playGhostRetreating();
-    }
-  } else if (scaredTimer.isRunning && !audioPlayer.ghostScared.playing()) {
-    audioPlayer.playGhostScared();
-  } else if (!scaredTimer.isRunning && !audioPlayer.ghostSiren.playing()) {
-    audioPlayer.playGhostSiren();
-  }
+  if (audioPlayer.ghostAudioWantsToPlay)
+    callback(audioPlayer, scaredTimer, retreatingTimers);
 }

--- a/client/src/components/game/mechanics/audio/manageGhostAudio.test.js
+++ b/client/src/components/game/mechanics/audio/manageGhostAudio.test.js
@@ -1,140 +1,44 @@
 import manageGhostAudio from "./manageGhostAudio";
 
-let mockSiren;
-let mockPlayingSiren;
-let mockScared;
-let mockPlayingScared;
-let mockRetreating;
-let mockPlayingRetreating;
-let mockAudioPlayer;
 let mockScaredTimer;
-let mockRunningScaredTimer;
 let mockRetreatingTimer;
-let mockRunningRetreatingTimer;
-let mockRetreatingTimers;
-let mockRunningRetreatingTimers;
+let mockPlayGhostAudio;
 
 describe("manageGhostAudio", () => {
   beforeEach(() => {
-    mockSiren = {
-      playing: () => false,
-    };
-    mockPlayingSiren = {
-      playing: () => true,
-    };
-    mockScared = {
-      playing: () => false,
-    };
-    mockPlayingScared = {
-      playing: () => true,
-    };
-    mockRetreating = {
-      playing: () => false,
-    };
-    mockPlayingRetreating = {
-      playing: () => true,
-    };
-    mockAudioPlayer = {
-      ghostSiren: mockSiren,
-      ghostScared: mockScared,
-      ghostRetreating: mockRetreating,
-      playGhostSiren: () => undefined,
-      playGhostScared: () => undefined,
-      playGhostRetreating: () => undefined,
-    };
-    mockScaredTimer = {
-      isRunning: false,
-    };
-    mockRunningScaredTimer = {
-      isRunning: true,
-    };
-    mockRetreatingTimer = {
-      isRunning: false,
-    };
-    mockRunningRetreatingTimer = {
-      isRunning: true,
-    };
-    mockRetreatingTimers = [
-      mockRetreatingTimer,
-      mockRetreatingTimer,
-      mockRetreatingTimer,
-      mockRetreatingTimer,
-    ];
-    mockRunningRetreatingTimers = [
-      mockRunningRetreatingTimer,
-      mockRunningRetreatingTimer,
-      mockRunningRetreatingTimer,
-      mockRunningRetreatingTimer,
-    ];
-    jest.spyOn(mockSiren, "playing");
-    jest.spyOn(mockPlayingSiren, "playing");
-    jest.spyOn(mockScared, "playing");
-    jest.spyOn(mockPlayingScared, "playing");
-    jest.spyOn(mockRetreating, "playing");
-    jest.spyOn(mockPlayingRetreating, "playing");
-    jest.spyOn(mockAudioPlayer, "playGhostSiren");
-    jest.spyOn(mockAudioPlayer, "playGhostScared");
-    jest.spyOn(mockAudioPlayer, "playGhostRetreating");
+    mockScaredTimer = "scaredTimer";
+    mockRetreatingTimer = "retreatingTimer";
+    mockPlayGhostAudio = jest.fn();
   });
 
-  it("calls playGhostRetreating on the audioPlayer if the retreating audio is not playing and any of the retreating timers are running", () => {
+  it("calls playGhostAudio if ghostAudioWantsToPlay in the audioPlayer is true", () => {
+    const mockAudioPlayer = {
+      ghostAudioWantsToPlay: true,
+    };
     manageGhostAudio(
       mockAudioPlayer,
-      mockRunningScaredTimer,
-      mockRunningRetreatingTimers
+      mockScaredTimer,
+      mockRetreatingTimer,
+      mockPlayGhostAudio
     );
-    expect(mockRetreating.playing).toHaveBeenCalledTimes(1);
-    expect(mockAudioPlayer.playGhostRetreating).toHaveBeenCalledTimes(1);
+    expect(mockPlayGhostAudio).toHaveBeenCalledTimes(1);
+    expect(mockPlayGhostAudio).toHaveBeenCalledWith(
+      mockAudioPlayer,
+      mockScaredTimer,
+      mockRetreatingTimer
+    );
   });
 
-  it("leaves the retreating audio playing if any of the retreating timers are running", () => {
-    mockAudioPlayer.ghostRetreating = mockPlayingRetreating;
+  it("does not call playGhostAudio if ghostAudioWantsToPlay in the audioPlayer is false", () => {
+    const mockAudioPlayer = {
+      ghostAudioWantsToPlay: false,
+    };
     manageGhostAudio(
       mockAudioPlayer,
-      mockRunningScaredTimer,
-      mockRunningRetreatingTimers
+      mockScaredTimer,
+      mockRetreatingTimer,
+      mockPlayGhostAudio
     );
-    expect(mockPlayingRetreating.playing).toHaveBeenCalledTimes(1);
-    expect(mockAudioPlayer.playGhostSiren).toHaveBeenCalledTimes(0);
-    expect(mockAudioPlayer.playGhostScared).toHaveBeenCalledTimes(0);
-    expect(mockAudioPlayer.playGhostRetreating).toHaveBeenCalledTimes(0);
-  });
-
-  it("calls playGhostScared on the audioPlayer if the scared audio is not playing and the scared timer is running", () => {
-    manageGhostAudio(
-      mockAudioPlayer,
-      mockRunningScaredTimer,
-      mockRetreatingTimers
-    );
-    expect(mockScared.playing).toHaveBeenCalledTimes(1);
-    expect(mockAudioPlayer.playGhostScared).toHaveBeenCalledTimes(1);
-  });
-
-  it("leaves the scared audio playing if the scared timer is running", () => {
-    mockAudioPlayer.ghostScared = mockPlayingScared;
-    manageGhostAudio(
-      mockAudioPlayer,
-      mockRunningScaredTimer,
-      mockRetreatingTimers
-    );
-    expect(mockPlayingScared.playing).toHaveBeenCalledTimes(1);
-    expect(mockAudioPlayer.playGhostSiren).toHaveBeenCalledTimes(0);
-    expect(mockAudioPlayer.playGhostScared).toHaveBeenCalledTimes(0);
-    expect(mockAudioPlayer.playGhostRetreating).toHaveBeenCalledTimes(0);
-  });
-
-  it("calls playGhostSiren on the audioPlayer if the siren audio is not playing and the scared timer is not running", () => {
-    manageGhostAudio(mockAudioPlayer, mockScaredTimer, mockRetreatingTimers);
-    expect(mockSiren.playing).toHaveBeenCalledTimes(1);
-    expect(mockAudioPlayer.playGhostSiren).toHaveBeenCalledTimes(1);
-  });
-
-  it("leaves the siren audio playing if the scared timer is not running", () => {
-    mockAudioPlayer.ghostSiren = mockPlayingSiren;
-    manageGhostAudio(mockAudioPlayer, mockScaredTimer, mockRetreatingTimers);
-    expect(mockPlayingSiren.playing).toHaveBeenCalledTimes(1);
-    expect(mockAudioPlayer.playGhostSiren).toHaveBeenCalledTimes(0);
-    expect(mockAudioPlayer.playGhostScared).toHaveBeenCalledTimes(0);
-    expect(mockAudioPlayer.playGhostRetreating).toHaveBeenCalledTimes(0);
+    expect(mockPlayGhostAudio).toHaveBeenCalledTimes(0);
   });
 });

--- a/client/src/components/game/mechanics/audio/playGhostAudio.js
+++ b/client/src/components/game/mechanics/audio/playGhostAudio.js
@@ -1,0 +1,19 @@
+export default function playGhostAudio(
+  audioPlayer,
+  scaredTimer,
+  retreatingTimers
+) {
+  let count = 0;
+  retreatingTimers.forEach((timer) => {
+    if (timer.isRunning) count++;
+  });
+  if (count > 0) {
+    if (!audioPlayer.ghostRetreating.playing()) {
+      audioPlayer.playGhostRetreating();
+    }
+  } else if (scaredTimer.isRunning && !audioPlayer.ghostScared.playing()) {
+    audioPlayer.playGhostScared();
+  } else if (!scaredTimer.isRunning && !audioPlayer.ghostSiren.playing()) {
+    audioPlayer.playGhostSiren();
+  }
+}

--- a/client/src/components/game/mechanics/audio/playGhostAudio.test.js
+++ b/client/src/components/game/mechanics/audio/playGhostAudio.test.js
@@ -1,0 +1,140 @@
+import playGhostAudio from "./playGhostAudio";
+
+let mockSiren;
+let mockPlayingSiren;
+let mockScared;
+let mockPlayingScared;
+let mockRetreating;
+let mockPlayingRetreating;
+let mockAudioPlayer;
+let mockScaredTimer;
+let mockRunningScaredTimer;
+let mockRetreatingTimer;
+let mockRunningRetreatingTimer;
+let mockRetreatingTimers;
+let mockRunningRetreatingTimers;
+
+describe("playGhostAudio", () => {
+  beforeEach(() => {
+    mockSiren = {
+      playing: () => false,
+    };
+    mockPlayingSiren = {
+      playing: () => true,
+    };
+    mockScared = {
+      playing: () => false,
+    };
+    mockPlayingScared = {
+      playing: () => true,
+    };
+    mockRetreating = {
+      playing: () => false,
+    };
+    mockPlayingRetreating = {
+      playing: () => true,
+    };
+    mockAudioPlayer = {
+      ghostSiren: mockSiren,
+      ghostScared: mockScared,
+      ghostRetreating: mockRetreating,
+      playGhostSiren: () => undefined,
+      playGhostScared: () => undefined,
+      playGhostRetreating: () => undefined,
+    };
+    mockScaredTimer = {
+      isRunning: false,
+    };
+    mockRunningScaredTimer = {
+      isRunning: true,
+    };
+    mockRetreatingTimer = {
+      isRunning: false,
+    };
+    mockRunningRetreatingTimer = {
+      isRunning: true,
+    };
+    mockRetreatingTimers = [
+      mockRetreatingTimer,
+      mockRetreatingTimer,
+      mockRetreatingTimer,
+      mockRetreatingTimer,
+    ];
+    mockRunningRetreatingTimers = [
+      mockRunningRetreatingTimer,
+      mockRunningRetreatingTimer,
+      mockRunningRetreatingTimer,
+      mockRunningRetreatingTimer,
+    ];
+    jest.spyOn(mockSiren, "playing");
+    jest.spyOn(mockPlayingSiren, "playing");
+    jest.spyOn(mockScared, "playing");
+    jest.spyOn(mockPlayingScared, "playing");
+    jest.spyOn(mockRetreating, "playing");
+    jest.spyOn(mockPlayingRetreating, "playing");
+    jest.spyOn(mockAudioPlayer, "playGhostSiren");
+    jest.spyOn(mockAudioPlayer, "playGhostScared");
+    jest.spyOn(mockAudioPlayer, "playGhostRetreating");
+  });
+
+  it("calls playGhostRetreating on the audioPlayer if the retreating audio is not playing and any of the retreating timers are running", () => {
+    playGhostAudio(
+      mockAudioPlayer,
+      mockRunningScaredTimer,
+      mockRunningRetreatingTimers
+    );
+    expect(mockRetreating.playing).toHaveBeenCalledTimes(1);
+    expect(mockAudioPlayer.playGhostRetreating).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the retreating audio playing if any of the retreating timers are running", () => {
+    mockAudioPlayer.ghostRetreating = mockPlayingRetreating;
+    playGhostAudio(
+      mockAudioPlayer,
+      mockRunningScaredTimer,
+      mockRunningRetreatingTimers
+    );
+    expect(mockPlayingRetreating.playing).toHaveBeenCalledTimes(1);
+    expect(mockAudioPlayer.playGhostSiren).toHaveBeenCalledTimes(0);
+    expect(mockAudioPlayer.playGhostScared).toHaveBeenCalledTimes(0);
+    expect(mockAudioPlayer.playGhostRetreating).toHaveBeenCalledTimes(0);
+  });
+
+  it("calls playGhostScared on the audioPlayer if the scared audio is not playing and the scared timer is running", () => {
+    playGhostAudio(
+      mockAudioPlayer,
+      mockRunningScaredTimer,
+      mockRetreatingTimers
+    );
+    expect(mockScared.playing).toHaveBeenCalledTimes(1);
+    expect(mockAudioPlayer.playGhostScared).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the scared audio playing if the scared timer is running", () => {
+    mockAudioPlayer.ghostScared = mockPlayingScared;
+    playGhostAudio(
+      mockAudioPlayer,
+      mockRunningScaredTimer,
+      mockRetreatingTimers
+    );
+    expect(mockPlayingScared.playing).toHaveBeenCalledTimes(1);
+    expect(mockAudioPlayer.playGhostSiren).toHaveBeenCalledTimes(0);
+    expect(mockAudioPlayer.playGhostScared).toHaveBeenCalledTimes(0);
+    expect(mockAudioPlayer.playGhostRetreating).toHaveBeenCalledTimes(0);
+  });
+
+  it("calls playGhostSiren on the audioPlayer if the siren audio is not playing and the scared timer is not running", () => {
+    playGhostAudio(mockAudioPlayer, mockScaredTimer, mockRetreatingTimers);
+    expect(mockSiren.playing).toHaveBeenCalledTimes(1);
+    expect(mockAudioPlayer.playGhostSiren).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the siren audio playing if the scared timer is not running", () => {
+    mockAudioPlayer.ghostSiren = mockPlayingSiren;
+    playGhostAudio(mockAudioPlayer, mockScaredTimer, mockRetreatingTimers);
+    expect(mockPlayingSiren.playing).toHaveBeenCalledTimes(1);
+    expect(mockAudioPlayer.playGhostSiren).toHaveBeenCalledTimes(0);
+    expect(mockAudioPlayer.playGhostScared).toHaveBeenCalledTimes(0);
+    expect(mockAudioPlayer.playGhostRetreating).toHaveBeenCalledTimes(0);
+  });
+});

--- a/client/src/components/game/mechanics/audio/resumeAudio.js
+++ b/client/src/components/game/mechanics/audio/resumeAudio.js
@@ -1,3 +1,3 @@
 export default function resumeAudio(audioPlayer) {
-  audioPlayer.playPacmanDeathAndLevelUpIfLoaded();
+  audioPlayer.playPacmanDeathAndLevelUpIfWantTo();
 }

--- a/client/src/components/game/mechanics/audio/resumeAudio.test.js
+++ b/client/src/components/game/mechanics/audio/resumeAudio.test.js
@@ -1,14 +1,14 @@
 import resumeAudio from "./resumeAudio";
 
 describe("resumeAudio", () => {
-  it("calls playPacmanDeathAndLevelUpIfLoaded on the audioPlayer", () => {
+  it("calls playPacmanDeathAndLevelUpIfWantTo on the audioPlayer", () => {
     const mockAudioPlayer = {
-      playPacmanDeathAndLevelUpIfLoaded: () => undefined,
+      playPacmanDeathAndLevelUpIfWantTo: () => undefined,
     };
-    jest.spyOn(mockAudioPlayer, "playPacmanDeathAndLevelUpIfLoaded");
+    jest.spyOn(mockAudioPlayer, "playPacmanDeathAndLevelUpIfWantTo");
     resumeAudio(mockAudioPlayer);
     expect(
-      mockAudioPlayer.playPacmanDeathAndLevelUpIfLoaded
+      mockAudioPlayer.playPacmanDeathAndLevelUpIfWantTo
     ).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/components/game/mechanics/eventListeners/addPauseDetection.js
+++ b/client/src/components/game/mechanics/eventListeners/addPauseDetection.js
@@ -42,7 +42,8 @@ export default function addPauseDetection(
             pacman,
             ghosts,
             cycleTimer,
-            scaredTimer
+            scaredTimer,
+            audioPlayer
           );
         }
       }

--- a/client/src/components/game/mechanics/eventListeners/addPauseDetection.js
+++ b/client/src/components/game/mechanics/eventListeners/addPauseDetection.js
@@ -42,8 +42,7 @@ export default function addPauseDetection(
             pacman,
             ghosts,
             cycleTimer,
-            scaredTimer,
-            audioPlayer
+            scaredTimer
           );
         }
       }

--- a/client/src/components/game/mechanics/eventListeners/addPauseDetection.test.js
+++ b/client/src/components/game/mechanics/eventListeners/addPauseDetection.test.js
@@ -257,7 +257,8 @@ describe("addPauseDetection", () => {
         mockPacman,
         mockGhosts,
         mockCycleTimer,
-        mockScaredTimer
+        mockScaredTimer,
+        mockAudioPlayer
       );
     });
   });

--- a/client/src/components/game/mechanics/eventListeners/addPauseDetection.test.js
+++ b/client/src/components/game/mechanics/eventListeners/addPauseDetection.test.js
@@ -140,7 +140,7 @@ describe("addPauseDetection", () => {
       expect(mockVariables.isGamePaused).toBeFalsy();
     });
 
-    it("call PauseAudioAndTimers if isGamePaused is intially false", () => {
+    it("calls PauseAudioAndTimers if isGamePaused is intially false", () => {
       addPauseDetection(
         mockVariables,
         mockCycleTimer,
@@ -169,7 +169,7 @@ describe("addPauseDetection", () => {
       );
     });
 
-    it("call loadPauseOverlay if isGamePaused is initially false", () => {
+    it("calls loadPauseOverlay if isGamePaused is initially false", () => {
       addPauseDetection(
         mockVariables,
         mockCycleTimer,
@@ -196,7 +196,7 @@ describe("addPauseDetection", () => {
       );
     });
 
-    it("call ResumeAudioAndTimers if isGamePaused is intially true", () => {
+    it("calls ResumeAudioAndTimers if isGamePaused is intially true", () => {
       addPauseDetection(
         mockVariables,
         mockCycleTimer,
@@ -226,7 +226,7 @@ describe("addPauseDetection", () => {
       );
     });
 
-    it("call resumeAnimation if isGamePaused is initially true", () => {
+    it("calls resumeAnimation if isGamePaused is initially true", () => {
       addPauseDetection(
         mockVariables,
         mockCycleTimer,
@@ -257,8 +257,7 @@ describe("addPauseDetection", () => {
         mockPacman,
         mockGhosts,
         mockCycleTimer,
-        mockScaredTimer,
-        mockAudioPlayer
+        mockScaredTimer
       );
     });
   });

--- a/client/src/components/game/mechanics/eventListeners/resumeAnimation.js
+++ b/client/src/components/game/mechanics/eventListeners/resumeAnimation.js
@@ -12,6 +12,7 @@ export default function resumeAnimation(
   ghosts,
   cycleTimer,
   scaredTimer,
+  audioPlayer,
   callbackOne = runDeathAnimation,
   callbackTwo = runLevelUpAnimation,
   callbackThree = playGame
@@ -26,7 +27,8 @@ export default function resumeAnimation(
       pacman,
       ghosts,
       cycleTimer,
-      scaredTimer
+      scaredTimer,
+      audioPlayer
     );
   } else if (pacman.isLevellingUp) {
     callbackTwo(

--- a/client/src/components/game/mechanics/eventListeners/resumeAnimation.js
+++ b/client/src/components/game/mechanics/eventListeners/resumeAnimation.js
@@ -12,7 +12,6 @@ export default function resumeAnimation(
   ghosts,
   cycleTimer,
   scaredTimer,
-  audioPlayer,
   callbackOne = runDeathAnimation,
   callbackTwo = runLevelUpAnimation,
   callbackThree = playGame
@@ -27,8 +26,7 @@ export default function resumeAnimation(
       pacman,
       ghosts,
       cycleTimer,
-      scaredTimer,
-      audioPlayer
+      scaredTimer
     );
   } else if (pacman.isLevellingUp) {
     callbackTwo(
@@ -40,7 +38,6 @@ export default function resumeAnimation(
       cycleTimer,
       scaredTimer,
       ctx,
-      audioPlayer,
       boundaries
     );
   } else {

--- a/client/src/components/game/mechanics/eventListeners/resumeAnimation.js
+++ b/client/src/components/game/mechanics/eventListeners/resumeAnimation.js
@@ -40,7 +40,8 @@ export default function resumeAnimation(
       cycleTimer,
       scaredTimer,
       ctx,
-      boundaries
+      boundaries,
+      audioPlayer
     );
   } else {
     callbackThree(variables.playerName, variables.reactRoot);

--- a/client/src/components/game/mechanics/eventListeners/resumeAnimation.test.js
+++ b/client/src/components/game/mechanics/eventListeners/resumeAnimation.test.js
@@ -11,6 +11,7 @@ let mockPowerUps;
 let mockGhosts;
 let mockCycleTimer;
 let mockScaredTimer;
+let mockAudioPlayer;
 let mockRunDeathAnimation;
 let mockRunLevelUpAnimation;
 let mockPlayGame;
@@ -40,6 +41,7 @@ describe("resumeAnimation", () => {
     mockGhosts = "ghosts";
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
+    mockAudioPlayer = "audioPlayer";
     mockRunDeathAnimation = jest.fn();
     mockRunLevelUpAnimation = jest.fn();
     mockPlayGame = jest.fn();
@@ -56,6 +58,7 @@ describe("resumeAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockRunDeathAnimation,
       mockRunLevelUpAnimation,
       mockPlayGame
@@ -70,7 +73,8 @@ describe("resumeAnimation", () => {
       mockShrinkingPacman,
       mockGhosts,
       mockCycleTimer,
-      mockScaredTimer
+      mockScaredTimer,
+      mockAudioPlayer
     );
   });
 
@@ -85,6 +89,7 @@ describe("resumeAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockRunDeathAnimation,
       mockRunLevelUpAnimation,
       mockPlayGame
@@ -114,6 +119,7 @@ describe("resumeAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockRunDeathAnimation,
       mockRunLevelUpAnimation,
       mockPlayGame

--- a/client/src/components/game/mechanics/eventListeners/resumeAnimation.test.js
+++ b/client/src/components/game/mechanics/eventListeners/resumeAnimation.test.js
@@ -11,7 +11,6 @@ let mockPowerUps;
 let mockGhosts;
 let mockCycleTimer;
 let mockScaredTimer;
-let mockAudioPlayer;
 let mockRunDeathAnimation;
 let mockRunLevelUpAnimation;
 let mockPlayGame;
@@ -41,7 +40,6 @@ describe("resumeAnimation", () => {
     mockGhosts = "ghosts";
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
-    mockAudioPlayer = "audioPlayer";
     mockRunDeathAnimation = jest.fn();
     mockRunLevelUpAnimation = jest.fn();
     mockPlayGame = jest.fn();
@@ -58,7 +56,6 @@ describe("resumeAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockRunDeathAnimation,
       mockRunLevelUpAnimation,
       mockPlayGame
@@ -73,8 +70,7 @@ describe("resumeAnimation", () => {
       mockShrinkingPacman,
       mockGhosts,
       mockCycleTimer,
-      mockScaredTimer,
-      mockAudioPlayer
+      mockScaredTimer
     );
   });
 
@@ -89,7 +85,6 @@ describe("resumeAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockRunDeathAnimation,
       mockRunLevelUpAnimation,
       mockPlayGame
@@ -104,7 +99,6 @@ describe("resumeAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries
     );
   });
@@ -120,7 +114,6 @@ describe("resumeAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockRunDeathAnimation,
       mockRunLevelUpAnimation,
       mockPlayGame

--- a/client/src/components/game/mechanics/eventListeners/resumeAnimation.test.js
+++ b/client/src/components/game/mechanics/eventListeners/resumeAnimation.test.js
@@ -104,7 +104,8 @@ describe("resumeAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockBoundaries
+      mockBoundaries,
+      mockAudioPlayer
     );
   });
 

--- a/client/src/components/game/mechanics/finishSetup.js
+++ b/client/src/components/game/mechanics/finishSetup.js
@@ -47,8 +47,5 @@ export default function finishSetup(
     pauseTextImage
   );
   variables.start = false;
-  audioPlayer.loadGhost();
   audioPlayer.playGhostSiren();
-  audioPlayer.unloadPacmanDeath();
-  audioPlayer.unloadLevelUp();
 }

--- a/client/src/components/game/mechanics/finishSetup.js
+++ b/client/src/components/game/mechanics/finishSetup.js
@@ -47,5 +47,5 @@ export default function finishSetup(
     pauseTextImage
   );
   variables.start = false;
-  audioPlayer.playGhostSiren();
+  audioPlayer.ghostAudioWantsToPlay = true;
 }

--- a/client/src/components/game/mechanics/finishSetup.test.js
+++ b/client/src/components/game/mechanics/finishSetup.test.js
@@ -36,7 +36,7 @@ describe("finishSetup", () => {
     mockScaredTimer = "scaredTimer";
     mockRetreatingTimers = "retreatingTimers";
     mockAudioPlayer = {
-      playGhostSiren: () => undefined,
+      ghostAudioWantsToPlay: false,
     };
     mockPacman = "pacman";
     mockCtx = "ctx";
@@ -211,8 +211,7 @@ describe("finishSetup", () => {
     expect(mockVariables.start).toBeFalsy();
   });
 
-  it("calls playGhostSiren on the audioPlayer", () => {
-    jest.spyOn(mockAudioPlayer, "playGhostSiren");
+  it("sets ghostAudioWantsToPlay in the audioPlayer to true", () => {
     finishSetup(
       mockVariables,
       mockName,
@@ -232,6 +231,6 @@ describe("finishSetup", () => {
       mockAddVisibilityDetection,
       mockAddPauseDetection
     );
-    expect(mockAudioPlayer.playGhostSiren).toHaveBeenCalledTimes(1);
+    expect(mockAudioPlayer.ghostAudioWantsToPlay).toBe(true);
   });
 });

--- a/client/src/components/game/mechanics/finishSetup.test.js
+++ b/client/src/components/game/mechanics/finishSetup.test.js
@@ -36,10 +36,7 @@ describe("finishSetup", () => {
     mockScaredTimer = "scaredTimer";
     mockRetreatingTimers = "retreatingTimers";
     mockAudioPlayer = {
-      loadGhost: () => undefined,
       playGhostSiren: () => undefined,
-      unloadPacmanDeath: () => undefined,
-      unloadLevelUp: () => undefined,
     };
     mockPacman = "pacman";
     mockCtx = "ctx";
@@ -214,30 +211,6 @@ describe("finishSetup", () => {
     expect(mockVariables.start).toBeFalsy();
   });
 
-  it("calls loadGhost on the audioPlayer", () => {
-    jest.spyOn(mockAudioPlayer, "loadGhost");
-    finishSetup(
-      mockVariables,
-      mockName,
-      mockReactRoot,
-      mockCycleTimer,
-      mockScaredTimer,
-      mockRetreatingTimers,
-      mockAudioPlayer,
-      mockPacman,
-      mockCtx,
-      mockBoundaries,
-      mockPellets,
-      mockPowerUps,
-      mockGhosts,
-      mockPauseTextImage,
-      mockAddDirectionDetection,
-      mockAddVisibilityDetection,
-      mockAddPauseDetection
-    );
-    expect(mockAudioPlayer.loadGhost).toHaveBeenCalledTimes(1);
-  });
-
   it("calls playGhostSiren on the audioPlayer", () => {
     jest.spyOn(mockAudioPlayer, "playGhostSiren");
     finishSetup(
@@ -260,53 +233,5 @@ describe("finishSetup", () => {
       mockAddPauseDetection
     );
     expect(mockAudioPlayer.playGhostSiren).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls unloadPacmanDeath on the audioPlayer", () => {
-    jest.spyOn(mockAudioPlayer, "unloadPacmanDeath");
-    finishSetup(
-      mockVariables,
-      mockName,
-      mockReactRoot,
-      mockCycleTimer,
-      mockScaredTimer,
-      mockRetreatingTimers,
-      mockAudioPlayer,
-      mockPacman,
-      mockCtx,
-      mockBoundaries,
-      mockPellets,
-      mockPowerUps,
-      mockGhosts,
-      mockPauseTextImage,
-      mockAddDirectionDetection,
-      mockAddVisibilityDetection,
-      mockAddPauseDetection
-    );
-    expect(mockAudioPlayer.unloadPacmanDeath).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls unloadLevelUp on the audioPlayer", () => {
-    jest.spyOn(mockAudioPlayer, "unloadLevelUp");
-    finishSetup(
-      mockVariables,
-      mockName,
-      mockReactRoot,
-      mockCycleTimer,
-      mockScaredTimer,
-      mockRetreatingTimers,
-      mockAudioPlayer,
-      mockPacman,
-      mockCtx,
-      mockBoundaries,
-      mockPellets,
-      mockPowerUps,
-      mockGhosts,
-      mockPauseTextImage,
-      mockAddDirectionDetection,
-      mockAddVisibilityDetection,
-      mockAddPauseDetection
-    );
-    expect(mockAudioPlayer.unloadLevelUp).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.js
@@ -29,7 +29,8 @@ export default function dealWithCollision(
       pacman,
       ghosts,
       cycleTimer,
-      scaredTimer
+      scaredTimer,
+      audioPlayer
     );
   } else if (ghost.isScared) {
     variables.score += 200 * Math.pow(2, variables.killCount);

--- a/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.js
@@ -28,8 +28,7 @@ export default function dealWithCollision(
       pacman,
       ghosts,
       cycleTimer,
-      scaredTimer,
-      audioPlayer
+      scaredTimer
     );
   } else if (ghost.isScared) {
     variables.score += 200 * Math.pow(2, variables.killCount);

--- a/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.js
@@ -17,8 +17,7 @@ export default function dealWithCollision(
   if (!ghost.isScared && !ghost.isRetreating) {
     pacman.radians = Math.PI / 4;
     cancelAnimationFrame(variables.animationId);
-    audioPlayer.unloadGhost();
-    audioPlayer.loadAndPlayPacmanDeath();
+    audioPlayer.playPacmanDeath();
     pacman.isShrinking = true;
     callback(
       variables,

--- a/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.js
@@ -17,6 +17,7 @@ export default function dealWithCollision(
   if (!ghost.isScared && !ghost.isRetreating) {
     pacman.radians = Math.PI / 4;
     cancelAnimationFrame(variables.animationId);
+    audioPlayer.stopGhostAudio();
     audioPlayer.playPacmanDeath();
     pacman.isShrinking = true;
     callback(

--- a/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.test.js
@@ -45,6 +45,7 @@ describe("dealWithCollision", () => {
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
     mockAudioPlayer = {
+      stopGhostAudio: () => undefined,
       playPacmanDeath: () => undefined,
     };
     mockCtx = "ctx";
@@ -93,6 +94,25 @@ describe("dealWithCollision", () => {
     expect(cancelAnimationFrame).toHaveBeenCalledWith(
       mockVariables.animationId
     );
+  });
+
+  it("calls stopGhostAudio on the audioPlayer if the ghost is not scared or retreating", () => {
+    jest.spyOn(mockAudioPlayer, "stopGhostAudio");
+    dealWithCollision(
+      mockGhost,
+      mockPacman,
+      mockVariables,
+      mockGhosts,
+      mockPellets,
+      mockPowerUps,
+      mockCycleTimer,
+      mockScaredTimer,
+      mockAudioPlayer,
+      mockCtx,
+      mockBoundaries,
+      mockRunDeathAnimation
+    );
+    expect(mockAudioPlayer.stopGhostAudio).toHaveBeenCalledTimes(1);
   });
 
   it("calls playPacmanDeath on the audioPlayer if the ghost is not scared or retreating", () => {

--- a/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.test.js
@@ -157,8 +157,7 @@ describe("dealWithCollision", () => {
       mockPacman,
       mockGhosts,
       mockCycleTimer,
-      mockScaredTimer,
-      mockAudioPlayer
+      mockScaredTimer
     );
   });
 

--- a/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.test.js
@@ -177,7 +177,8 @@ describe("dealWithCollision", () => {
       mockPacman,
       mockGhosts,
       mockCycleTimer,
-      mockScaredTimer
+      mockScaredTimer,
+      mockAudioPlayer
     );
   });
 

--- a/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/dealWithCollision.test.js
@@ -45,8 +45,7 @@ describe("dealWithCollision", () => {
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
     mockAudioPlayer = {
-      unloadGhost: () => undefined,
-      loadAndPlayPacmanDeath: () => undefined,
+      playPacmanDeath: () => undefined,
     };
     mockCtx = "ctx";
     mockBoundaries = "boundaries";
@@ -96,8 +95,8 @@ describe("dealWithCollision", () => {
     );
   });
 
-  it("calls unloadGhost on the audioPlayer if the ghost is not scared or retreating", () => {
-    jest.spyOn(mockAudioPlayer, "unloadGhost");
+  it("calls playPacmanDeath on the audioPlayer if the ghost is not scared or retreating", () => {
+    jest.spyOn(mockAudioPlayer, "playPacmanDeath");
     dealWithCollision(
       mockGhost,
       mockPacman,
@@ -112,26 +111,7 @@ describe("dealWithCollision", () => {
       mockBoundaries,
       mockRunDeathAnimation
     );
-    expect(mockAudioPlayer.unloadGhost).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls loadAndPlayPacmanDeath on the audioPlayer if the ghost is not scared or retreating", () => {
-    jest.spyOn(mockAudioPlayer, "loadAndPlayPacmanDeath");
-    dealWithCollision(
-      mockGhost,
-      mockPacman,
-      mockVariables,
-      mockGhosts,
-      mockPellets,
-      mockPowerUps,
-      mockCycleTimer,
-      mockScaredTimer,
-      mockAudioPlayer,
-      mockCtx,
-      mockBoundaries,
-      mockRunDeathAnimation
-    );
-    expect(mockAudioPlayer.loadAndPlayPacmanDeath).toHaveBeenCalledTimes(1);
+    expect(mockAudioPlayer.playPacmanDeath).toHaveBeenCalledTimes(1);
   });
 
   it("changes isShrinking in Pac-Man to true if the ghost is not scared or retreating", () => {

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/animation/runDeathAnimation.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/animation/runDeathAnimation.js
@@ -11,7 +11,6 @@ export default function runDeathAnimation(
   ghosts,
   cycleTimer,
   scaredTimer,
-  audioPlayer,
   callbackOne = runDeathAnimation,
   callbackTwo = drawBoard,
   callbackThree = checkPacmanLives
@@ -26,8 +25,7 @@ export default function runDeathAnimation(
       pacman,
       ghosts,
       cycleTimer,
-      scaredTimer,
-      audioPlayer
+      scaredTimer
     )
   );
   callbackTwo(ctx, boundaries, pellets, powerUps);
@@ -36,7 +34,6 @@ export default function runDeathAnimation(
   } else {
     pacman.isShrinking = false;
     cancelAnimationFrame(variables.animationId);
-    audioPlayer.unloadPacmanDeath();
     callbackThree(
       pacman,
       variables,
@@ -45,7 +42,6 @@ export default function runDeathAnimation(
       ghosts,
       cycleTimer,
       scaredTimer,
-      audioPlayer,
       ctx
     );
   }

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/animation/runDeathAnimation.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/animation/runDeathAnimation.js
@@ -11,6 +11,7 @@ export default function runDeathAnimation(
   ghosts,
   cycleTimer,
   scaredTimer,
+  audioPlayer,
   callbackOne = runDeathAnimation,
   callbackTwo = drawBoard,
   callbackThree = checkPacmanLives
@@ -25,7 +26,8 @@ export default function runDeathAnimation(
       pacman,
       ghosts,
       cycleTimer,
-      scaredTimer
+      scaredTimer,
+      audioPlayer
     )
   );
   callbackTwo(ctx, boundaries, pellets, powerUps);
@@ -42,7 +44,8 @@ export default function runDeathAnimation(
       ghosts,
       cycleTimer,
       scaredTimer,
-      ctx
+      ctx,
+      audioPlayer
     );
   }
 }

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/animation/runDeathAnimation.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/animation/runDeathAnimation.test.js
@@ -12,6 +12,7 @@ let mockShrunkPacman;
 let mockGhosts;
 let mockCycleTimer;
 let mockScaredTimer;
+let mockAudioPlayer;
 let mockRunDeathAnimation;
 let mockDrawBoard;
 let mockCheckPacmanLives;
@@ -37,6 +38,7 @@ describe("runDeathAnimation", () => {
     mockGhosts = "ghosts";
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
+    mockAudioPlayer = "audioPlayer";
     mockRunDeathAnimation = jest.fn();
     mockDrawBoard = jest.fn();
     mockCheckPacmanLives = jest.fn();
@@ -54,6 +56,7 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -71,7 +74,8 @@ describe("runDeathAnimation", () => {
       mockPacman,
       mockGhosts,
       mockCycleTimer,
-      mockScaredTimer
+      mockScaredTimer,
+      mockAudioPlayer
     );
   });
 
@@ -86,6 +90,7 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -111,6 +116,7 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -130,6 +136,7 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -149,6 +156,7 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -170,6 +178,7 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -183,7 +192,8 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockCtx
+      mockCtx,
+      mockAudioPlayer
     );
   });
 });

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/animation/runDeathAnimation.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/animation/runDeathAnimation.test.js
@@ -12,7 +12,6 @@ let mockShrunkPacman;
 let mockGhosts;
 let mockCycleTimer;
 let mockScaredTimer;
-let mockAudioPlayer;
 let mockRunDeathAnimation;
 let mockDrawBoard;
 let mockCheckPacmanLives;
@@ -38,9 +37,6 @@ describe("runDeathAnimation", () => {
     mockGhosts = "ghosts";
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
-    mockAudioPlayer = {
-      unloadPacmanDeath: () => undefined,
-    };
     mockRunDeathAnimation = jest.fn();
     mockDrawBoard = jest.fn();
     mockCheckPacmanLives = jest.fn();
@@ -58,7 +54,6 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -76,8 +71,7 @@ describe("runDeathAnimation", () => {
       mockPacman,
       mockGhosts,
       mockCycleTimer,
-      mockScaredTimer,
-      mockAudioPlayer
+      mockScaredTimer
     );
   });
 
@@ -92,7 +86,6 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -118,7 +111,6 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -138,7 +130,6 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -158,7 +149,6 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -167,26 +157,6 @@ describe("runDeathAnimation", () => {
     expect(cancelAnimationFrame).toHaveBeenCalledWith(
       mockVariables.animationId
     );
-  });
-
-  it("calls unloadPacmanDeath on the audioPlayer when Pac-Man's death animation has finished", () => {
-    jest.spyOn(mockAudioPlayer, "unloadPacmanDeath");
-    runDeathAnimation(
-      mockVariables,
-      mockCtx,
-      mockBoundaries,
-      mockPellets,
-      mockPowerUps,
-      mockShrunkPacman,
-      mockGhosts,
-      mockCycleTimer,
-      mockScaredTimer,
-      mockAudioPlayer,
-      mockRunDeathAnimation,
-      mockDrawBoard,
-      mockCheckPacmanLives
-    );
-    expect(mockAudioPlayer.unloadPacmanDeath).toHaveBeenCalledTimes(1);
   });
 
   it("calls checkPacmanLives when Pac-Man's death animation has finished", () => {
@@ -200,7 +170,6 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockRunDeathAnimation,
       mockDrawBoard,
       mockCheckPacmanLives
@@ -214,7 +183,6 @@ describe("runDeathAnimation", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockCtx
     );
   });

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/checkPacmanLives.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/checkPacmanLives.js
@@ -9,7 +9,6 @@ export default function checkPacmanLives(
   ghosts,
   cycleTimer,
   scaredTimer,
-  audioPlayer,
   ctx,
   callbackOne = endGame,
   callbackTwo = resetAfterDeath
@@ -27,13 +26,6 @@ export default function checkPacmanLives(
     );
   } else {
     pacman.lives--;
-    callbackTwo(
-      pacman,
-      variables,
-      ghosts,
-      cycleTimer,
-      scaredTimer,
-      audioPlayer
-    );
+    callbackTwo(pacman, variables, ghosts, cycleTimer, scaredTimer);
   }
 }

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/checkPacmanLives.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/checkPacmanLives.js
@@ -10,6 +10,7 @@ export default function checkPacmanLives(
   cycleTimer,
   scaredTimer,
   ctx,
+  audioPlayer,
   callbackOne = endGame,
   callbackTwo = resetAfterDeath
 ) {
@@ -26,6 +27,13 @@ export default function checkPacmanLives(
     );
   } else {
     pacman.lives--;
-    callbackTwo(pacman, variables, ghosts, cycleTimer, scaredTimer);
+    callbackTwo(
+      pacman,
+      variables,
+      ghosts,
+      cycleTimer,
+      scaredTimer,
+      audioPlayer
+    );
   }
 }

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/checkPacmanLives.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/checkPacmanLives.test.js
@@ -9,6 +9,7 @@ let mockPowerUps;
 let mockCycleTimer;
 let mockScaredTimer;
 let mockCtx;
+let mockAudioPlayer;
 let mockEndGame;
 let mockResetAfterDeath;
 
@@ -27,6 +28,7 @@ describe("checkPacmanLives", () => {
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
     mockCtx = "ctx";
+    mockAudioPlayer = "audioPlayer";
     mockEndGame = jest.fn();
     mockResetAfterDeath = jest.fn();
   });
@@ -41,6 +43,7 @@ describe("checkPacmanLives", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
+      mockAudioPlayer,
       mockEndGame,
       mockResetAfterDeath
     );
@@ -67,6 +70,7 @@ describe("checkPacmanLives", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
+      mockAudioPlayer,
       mockEndGame,
       mockResetAfterDeath
     );
@@ -83,6 +87,7 @@ describe("checkPacmanLives", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
+      mockAudioPlayer,
       mockEndGame,
       mockResetAfterDeath
     );
@@ -92,7 +97,8 @@ describe("checkPacmanLives", () => {
       mockVariables,
       mockGhosts,
       mockCycleTimer,
-      mockScaredTimer
+      mockScaredTimer,
+      mockAudioPlayer
     );
   });
 });

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/checkPacmanLives.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/checkPacmanLives.test.js
@@ -8,7 +8,6 @@ let mockPellets;
 let mockPowerUps;
 let mockCycleTimer;
 let mockScaredTimer;
-let mockAudioPlayer;
 let mockCtx;
 let mockEndGame;
 let mockResetAfterDeath;
@@ -27,7 +26,6 @@ describe("checkPacmanLives", () => {
     mockPowerUps = "powerUps";
     mockCycleTimer = "cycleTimer";
     mockScaredTimer = "scaredTimer";
-    mockAudioPlayer = "audioPlayer";
     mockCtx = "ctx";
     mockEndGame = jest.fn();
     mockResetAfterDeath = jest.fn();
@@ -42,7 +40,6 @@ describe("checkPacmanLives", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockCtx,
       mockEndGame,
       mockResetAfterDeath
@@ -69,7 +66,6 @@ describe("checkPacmanLives", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockCtx,
       mockEndGame,
       mockResetAfterDeath
@@ -86,7 +82,6 @@ describe("checkPacmanLives", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockCtx,
       mockEndGame,
       mockResetAfterDeath
@@ -97,8 +92,7 @@ describe("checkPacmanLives", () => {
       mockVariables,
       mockGhosts,
       mockCycleTimer,
-      mockScaredTimer,
-      mockAudioPlayer
+      mockScaredTimer
     );
   });
 });

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/resetAfterDeath.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/resetAfterDeath.js
@@ -6,6 +6,7 @@ export default function resetAfterDeath(
   ghosts,
   cycleTimer,
   scaredTimer,
+  audioPlayer,
   callbackOne = playGame
 ) {
   pacman.reset();
@@ -16,5 +17,6 @@ export default function resetAfterDeath(
     ghost.reset();
   });
   cycleTimer.start();
+  audioPlayer.ghostAudioWantsToPlay = true;
   callbackOne(variables.playerName, variables.reactRoot);
 }

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/resetAfterDeath.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/resetAfterDeath.js
@@ -6,7 +6,6 @@ export default function resetAfterDeath(
   ghosts,
   cycleTimer,
   scaredTimer,
-  audioPlayer,
   callbackOne = playGame
 ) {
   pacman.reset();
@@ -17,6 +16,5 @@ export default function resetAfterDeath(
     ghost.reset();
   });
   cycleTimer.start();
-  audioPlayer.loadGhost();
   callbackOne(variables.playerName, variables.reactRoot);
 }

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/resetAfterDeath.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/resetAfterDeath.test.js
@@ -6,6 +6,7 @@ let mockCycleTimer;
 let mockScaredTimer;
 let mockGhost;
 let mockGhosts;
+let mockAudioPlayer;
 let mockPlayGame;
 
 describe("resetAfterDeath", () => {
@@ -29,6 +30,9 @@ describe("resetAfterDeath", () => {
       reset: () => undefined,
     };
     mockGhosts = [mockGhost, mockGhost, mockGhost];
+    mockAudioPlayer = {
+      ghostAudioWantsToPlay: false,
+    };
     mockPlayGame = jest.fn();
   });
 
@@ -40,6 +44,7 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockPacman.reset).toHaveBeenCalledTimes(1);
@@ -52,6 +57,7 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockVariables.lastKeyPressed).toBe("");
@@ -65,6 +71,7 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockCycleTimer.reset).toHaveBeenCalledTimes(1);
@@ -78,6 +85,7 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockScaredTimer.reset).toHaveBeenCalledTimes(1);
@@ -91,6 +99,7 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockGhost.reset).toHaveBeenCalledTimes(3);
@@ -104,9 +113,23 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockCycleTimer.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets ghostAudioWantsToPlay in the audioPlayer to true", () => {
+    resetAfterDeath(
+      mockPacman,
+      mockVariables,
+      mockGhosts,
+      mockCycleTimer,
+      mockScaredTimer,
+      mockAudioPlayer,
+      mockPlayGame
+    );
+    expect(mockAudioPlayer.ghostAudioWantsToPlay).toBe(true);
   });
 
   it("calls playGame", () => {
@@ -116,6 +139,7 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockPlayGame).toHaveBeenCalledTimes(1);

--- a/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/resetAfterDeath.test.js
+++ b/client/src/components/game/mechanics/ghosts/collisions/pacmanDeath/resetAfterDeath.test.js
@@ -6,7 +6,6 @@ let mockCycleTimer;
 let mockScaredTimer;
 let mockGhost;
 let mockGhosts;
-let mockAudioPlayer;
 let mockPlayGame;
 
 describe("resetAfterDeath", () => {
@@ -30,9 +29,6 @@ describe("resetAfterDeath", () => {
       reset: () => undefined,
     };
     mockGhosts = [mockGhost, mockGhost, mockGhost];
-    mockAudioPlayer = {
-      loadGhost: () => undefined,
-    };
     mockPlayGame = jest.fn();
   });
 
@@ -44,7 +40,6 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockPacman.reset).toHaveBeenCalledTimes(1);
@@ -57,7 +52,6 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockVariables.lastKeyPressed).toBe("");
@@ -71,7 +65,6 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockCycleTimer.reset).toHaveBeenCalledTimes(1);
@@ -85,7 +78,6 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockScaredTimer.reset).toHaveBeenCalledTimes(1);
@@ -99,7 +91,6 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockGhost.reset).toHaveBeenCalledTimes(3);
@@ -113,24 +104,9 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockCycleTimer.start).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls loadGhost on the audioPlayer", () => {
-    jest.spyOn(mockAudioPlayer, "loadGhost");
-    resetAfterDeath(
-      mockPacman,
-      mockVariables,
-      mockGhosts,
-      mockCycleTimer,
-      mockScaredTimer,
-      mockAudioPlayer,
-      mockPlayGame
-    );
-    expect(mockAudioPlayer.loadGhost).toHaveBeenCalledTimes(1);
   });
 
   it("calls playGame", () => {
@@ -140,7 +116,6 @@ describe("resetAfterDeath", () => {
       mockGhosts,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockPlayGame).toHaveBeenCalledTimes(1);

--- a/client/src/components/game/mechanics/pellets/checkLevelUpCondition.js
+++ b/client/src/components/game/mechanics/pellets/checkLevelUpCondition.js
@@ -20,6 +20,7 @@ export default function checkLevelUpCondition(
     }
     if (eatenPellets === pellets.length) {
       cancelAnimationFrame(variables.animationId);
+      audioPlayer.stopGhostAudio();
       audioPlayer.playLevelUp();
       pacman.isLevellingUp = true;
       callback(

--- a/client/src/components/game/mechanics/pellets/checkLevelUpCondition.js
+++ b/client/src/components/game/mechanics/pellets/checkLevelUpCondition.js
@@ -32,7 +32,8 @@ export default function checkLevelUpCondition(
         cycleTimer,
         scaredTimer,
         ctx,
-        boundaries
+        boundaries,
+        audioPlayer
       );
     }
   });

--- a/client/src/components/game/mechanics/pellets/checkLevelUpCondition.js
+++ b/client/src/components/game/mechanics/pellets/checkLevelUpCondition.js
@@ -20,8 +20,7 @@ export default function checkLevelUpCondition(
     }
     if (eatenPellets === pellets.length) {
       cancelAnimationFrame(variables.animationId);
-      audioPlayer.unloadGhost();
-      audioPlayer.loadAndPlayLevelUp();
+      audioPlayer.playLevelUp();
       pacman.isLevellingUp = true;
       callback(
         variables,

--- a/client/src/components/game/mechanics/pellets/checkLevelUpCondition.js
+++ b/client/src/components/game/mechanics/pellets/checkLevelUpCondition.js
@@ -31,7 +31,6 @@ export default function checkLevelUpCondition(
         cycleTimer,
         scaredTimer,
         ctx,
-        audioPlayer,
         boundaries
       );
     }

--- a/client/src/components/game/mechanics/pellets/checkLevelUpCondition.test.js
+++ b/client/src/components/game/mechanics/pellets/checkLevelUpCondition.test.js
@@ -143,7 +143,8 @@ describe("checkLevelUpCondition", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockBoundaries
+      mockBoundaries,
+      mockAudioPlayer
     );
   });
 

--- a/client/src/components/game/mechanics/pellets/checkLevelUpCondition.test.js
+++ b/client/src/components/game/mechanics/pellets/checkLevelUpCondition.test.js
@@ -38,8 +38,7 @@ describe("checkLevelUpCondition", () => {
     mockScaredTimer = "scaredTimer";
     mockCtx = "ctx";
     mockAudioPlayer = {
-      unloadGhost: () => undefined,
-      loadAndPlayLevelUp: () => undefined,
+      playLevelUp: () => undefined,
     };
     mockBoundaries = "boundaries";
     mockRunLevelUpAnimation = jest.fn();
@@ -66,8 +65,8 @@ describe("checkLevelUpCondition", () => {
     );
   });
 
-  it("calls unloadGhost on the audioPlayer if all pellets have been eaten", () => {
-    jest.spyOn(mockAudioPlayer, "unloadGhost");
+  it("calls playLevelUp on the audioPlayer if all pellets have been eaten", () => {
+    jest.spyOn(mockAudioPlayer, "playLevelUp");
     checkLevelUpCondition(
       mockEatenPellets,
       mockPacman,
@@ -81,25 +80,7 @@ describe("checkLevelUpCondition", () => {
       mockBoundaries,
       mockRunLevelUpAnimation
     );
-    expect(mockAudioPlayer.unloadGhost).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls loadAndPlayLevelUp on the audioPlayer if all pellets have been eaten", () => {
-    jest.spyOn(mockAudioPlayer, "loadAndPlayLevelUp");
-    checkLevelUpCondition(
-      mockEatenPellets,
-      mockPacman,
-      mockVariables,
-      mockGhosts,
-      mockPowerUps,
-      mockCycleTimer,
-      mockScaredTimer,
-      mockCtx,
-      mockAudioPlayer,
-      mockBoundaries,
-      mockRunLevelUpAnimation
-    );
-    expect(mockAudioPlayer.loadAndPlayLevelUp).toHaveBeenCalledTimes(1);
+    expect(mockAudioPlayer.playLevelUp).toHaveBeenCalledTimes(1);
   });
 
   it("changes isLevellingUp in Pac-Man to true if all pellets have been eaten", () => {

--- a/client/src/components/game/mechanics/pellets/checkLevelUpCondition.test.js
+++ b/client/src/components/game/mechanics/pellets/checkLevelUpCondition.test.js
@@ -124,7 +124,6 @@ describe("checkLevelUpCondition", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries
     );
   });

--- a/client/src/components/game/mechanics/pellets/checkLevelUpCondition.test.js
+++ b/client/src/components/game/mechanics/pellets/checkLevelUpCondition.test.js
@@ -38,6 +38,7 @@ describe("checkLevelUpCondition", () => {
     mockScaredTimer = "scaredTimer";
     mockCtx = "ctx";
     mockAudioPlayer = {
+      stopGhostAudio: () => undefined,
       playLevelUp: () => undefined,
     };
     mockBoundaries = "boundaries";
@@ -63,6 +64,24 @@ describe("checkLevelUpCondition", () => {
     expect(cancelAnimationFrame).toHaveBeenCalledWith(
       mockVariables.animationId
     );
+  });
+
+  it("calls stopGhostAudio on the audioPlayer if all pellets have been eaten", () => {
+    jest.spyOn(mockAudioPlayer, "stopGhostAudio");
+    checkLevelUpCondition(
+      mockEatenPellets,
+      mockPacman,
+      mockVariables,
+      mockGhosts,
+      mockPowerUps,
+      mockCycleTimer,
+      mockScaredTimer,
+      mockCtx,
+      mockAudioPlayer,
+      mockBoundaries,
+      mockRunLevelUpAnimation
+    );
+    expect(mockAudioPlayer.stopGhostAudio).toHaveBeenCalledTimes(1);
   });
 
   it("calls playLevelUp on the audioPlayer if all pellets have been eaten", () => {

--- a/client/src/components/game/mechanics/pellets/levelUpAnimation/resetAfterLevelUp.js
+++ b/client/src/components/game/mechanics/pellets/levelUpAnimation/resetAfterLevelUp.js
@@ -8,7 +8,6 @@ export default function resetAfterLevelUp(
   powerUps,
   cycleTimer,
   scaredTimer,
-  audioPlayer,
   callback = playGame
 ) {
   pacman.reset();
@@ -26,7 +25,6 @@ export default function resetAfterLevelUp(
   powerUps.forEach((powerUp) => {
     if (powerUp.hasBeenEaten) powerUp.changeEatenState();
   });
-  audioPlayer.loadGhost();
   cycleTimer.start();
   callback();
 }

--- a/client/src/components/game/mechanics/pellets/levelUpAnimation/resetAfterLevelUp.js
+++ b/client/src/components/game/mechanics/pellets/levelUpAnimation/resetAfterLevelUp.js
@@ -8,6 +8,7 @@ export default function resetAfterLevelUp(
   powerUps,
   cycleTimer,
   scaredTimer,
+  audioPlayer,
   callback = playGame
 ) {
   pacman.reset();
@@ -25,6 +26,7 @@ export default function resetAfterLevelUp(
   powerUps.forEach((powerUp) => {
     if (powerUp.hasBeenEaten) powerUp.changeEatenState();
   });
+  audioPlayer.ghostAudioWantsToPlay = true;
   cycleTimer.start();
   callback();
 }

--- a/client/src/components/game/mechanics/pellets/levelUpAnimation/resetAfterLevelUp.test.js
+++ b/client/src/components/game/mechanics/pellets/levelUpAnimation/resetAfterLevelUp.test.js
@@ -12,6 +12,7 @@ let mockUneatenPowerUp;
 let mockUneatenPowerUps;
 let mockCycleTimer;
 let mockScaredTimer;
+let mockAudioPlayer;
 let mockPlayGame;
 
 describe("resetAfterLevelUp", () => {
@@ -49,6 +50,9 @@ describe("resetAfterLevelUp", () => {
       reset: () => undefined,
       duration: 5000,
     };
+    mockAudioPlayer = {
+      ghostAudioWantsToPlay: false,
+    };
     mockPlayGame = jest.fn();
   });
 
@@ -62,6 +66,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockPacman.reset).toHaveBeenCalledTimes(1);
@@ -76,6 +81,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockVariables.lastKeyPressed).toBe("");
@@ -90,6 +96,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockVariables.levelUpCount).toBe(0);
@@ -105,6 +112,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockCycleTimer.reset).toHaveBeenCalledTimes(1);
@@ -120,6 +128,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockScaredTimer.reset).toHaveBeenCalledTimes(1);
@@ -134,6 +143,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockScaredTimer.duration).toBe(4500);
@@ -152,6 +162,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimerZero,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockScaredTimerZero.duration).toBe(0);
@@ -167,6 +178,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockGhost.reset).toHaveBeenCalledTimes(3);
@@ -182,6 +194,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockPellet.changeEatenState).toHaveBeenCalledTimes(2);
@@ -197,6 +210,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockEatenPowerUp.changeEatenState).toHaveBeenCalledTimes(1);
@@ -212,9 +226,25 @@ describe("resetAfterLevelUp", () => {
       mockUneatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockUneatenPowerUp.changeEatenState).toHaveBeenCalledTimes(0);
+  });
+
+  it("sets ghostAudioWantsToPlay to true", () => {
+    resetAfterLevelUp(
+      mockPacman,
+      mockVariables,
+      mockGhosts,
+      mockPellets,
+      mockEatenPowerUps,
+      mockCycleTimer,
+      mockScaredTimer,
+      mockAudioPlayer,
+      mockPlayGame
+    );
+    expect(mockAudioPlayer.ghostAudioWantsToPlay).toBe(true);
   });
 
   it("calls start on the cycle timer to restart it", () => {
@@ -227,6 +257,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockCycleTimer.start).toHaveBeenCalledTimes(1);
@@ -241,6 +272,7 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
+      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockPlayGame).toHaveBeenCalledTimes(1);

--- a/client/src/components/game/mechanics/pellets/levelUpAnimation/resetAfterLevelUp.test.js
+++ b/client/src/components/game/mechanics/pellets/levelUpAnimation/resetAfterLevelUp.test.js
@@ -12,7 +12,6 @@ let mockUneatenPowerUp;
 let mockUneatenPowerUps;
 let mockCycleTimer;
 let mockScaredTimer;
-let mockAudioPlayer;
 let mockPlayGame;
 
 describe("resetAfterLevelUp", () => {
@@ -50,9 +49,6 @@ describe("resetAfterLevelUp", () => {
       reset: () => undefined,
       duration: 5000,
     };
-    mockAudioPlayer = {
-      loadGhost: () => undefined,
-    };
     mockPlayGame = jest.fn();
   });
 
@@ -66,7 +62,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockPacman.reset).toHaveBeenCalledTimes(1);
@@ -81,7 +76,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockVariables.lastKeyPressed).toBe("");
@@ -96,7 +90,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockVariables.levelUpCount).toBe(0);
@@ -112,7 +105,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockCycleTimer.reset).toHaveBeenCalledTimes(1);
@@ -128,7 +120,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockScaredTimer.reset).toHaveBeenCalledTimes(1);
@@ -143,7 +134,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockScaredTimer.duration).toBe(4500);
@@ -162,7 +152,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimerZero,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockScaredTimerZero.duration).toBe(0);
@@ -178,7 +167,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockGhost.reset).toHaveBeenCalledTimes(3);
@@ -194,7 +182,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockPellet.changeEatenState).toHaveBeenCalledTimes(2);
@@ -210,7 +197,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockEatenPowerUp.changeEatenState).toHaveBeenCalledTimes(1);
@@ -226,26 +212,9 @@ describe("resetAfterLevelUp", () => {
       mockUneatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockUneatenPowerUp.changeEatenState).toHaveBeenCalledTimes(0);
-  });
-
-  it("calls loadGhost on the audioPlayer", () => {
-    jest.spyOn(mockAudioPlayer, "loadGhost");
-    resetAfterLevelUp(
-      mockPacman,
-      mockVariables,
-      mockGhosts,
-      mockPellets,
-      mockEatenPowerUps,
-      mockCycleTimer,
-      mockScaredTimer,
-      mockAudioPlayer,
-      mockPlayGame
-    );
-    expect(mockAudioPlayer.loadGhost).toHaveBeenCalledTimes(1);
   });
 
   it("calls start on the cycle timer to restart it", () => {
@@ -258,7 +227,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockCycleTimer.start).toHaveBeenCalledTimes(1);
@@ -273,7 +241,6 @@ describe("resetAfterLevelUp", () => {
       mockEatenPowerUps,
       mockCycleTimer,
       mockScaredTimer,
-      mockAudioPlayer,
       mockPlayGame
     );
     expect(mockPlayGame).toHaveBeenCalledTimes(1);

--- a/client/src/components/game/mechanics/pellets/levelUpAnimation/runLevelUpAnimation.js
+++ b/client/src/components/game/mechanics/pellets/levelUpAnimation/runLevelUpAnimation.js
@@ -10,7 +10,6 @@ export default function runLevelUpAnimation(
   cycleTimer,
   scaredTimer,
   ctx,
-  audioPlayer,
   boundaries,
   callbackOne = runLevelUpAnimation,
   callbackTwo = drawLevelUpBoard,
@@ -26,7 +25,6 @@ export default function runLevelUpAnimation(
       cycleTimer,
       scaredTimer,
       ctx,
-      audioPlayer,
       boundaries
     )
   );
@@ -37,7 +35,6 @@ export default function runLevelUpAnimation(
   if (variables.levelUpCount >= 350) {
     pacman.isLevellingUp = false;
     cancelAnimationFrame(variables.animationId);
-    audioPlayer.unloadLevelUp();
     variables.level++;
     callbackThree(
       pacman,
@@ -46,8 +43,7 @@ export default function runLevelUpAnimation(
       pellets,
       powerUps,
       cycleTimer,
-      scaredTimer,
-      audioPlayer
+      scaredTimer
     );
   }
 }

--- a/client/src/components/game/mechanics/pellets/levelUpAnimation/runLevelUpAnimation.js
+++ b/client/src/components/game/mechanics/pellets/levelUpAnimation/runLevelUpAnimation.js
@@ -11,6 +11,7 @@ export default function runLevelUpAnimation(
   scaredTimer,
   ctx,
   boundaries,
+  audioPlayer,
   callbackOne = runLevelUpAnimation,
   callbackTwo = drawLevelUpBoard,
   callbackThree = resetAfterLevelUp
@@ -25,7 +26,8 @@ export default function runLevelUpAnimation(
       cycleTimer,
       scaredTimer,
       ctx,
-      boundaries
+      boundaries,
+      audioPlayer
     )
   );
   callbackTwo(ctx, boundaries);
@@ -43,7 +45,8 @@ export default function runLevelUpAnimation(
       pellets,
       powerUps,
       cycleTimer,
-      scaredTimer
+      scaredTimer,
+      audioPlayer
     );
   }
 }

--- a/client/src/components/game/mechanics/pellets/levelUpAnimation/runLevelUpAnimation.test.js
+++ b/client/src/components/game/mechanics/pellets/levelUpAnimation/runLevelUpAnimation.test.js
@@ -12,6 +12,7 @@ let mockScaredTimer;
 let mockCtx;
 let mockBoundary;
 let mockBoundaries;
+let mockAudioPlayer;
 let mockRunLevelUpAnimation;
 let mockDrawLevelUpBoard;
 let mockResetAfterLevelUp;
@@ -41,6 +42,7 @@ describe("runLevelUpAnimation", () => {
       flash: () => undefined,
     };
     mockBoundaries = [mockBoundary, mockBoundary];
+    mockAudioPlayer = "audioPlayer";
     mockRunLevelUpAnimation = jest.fn();
     mockDrawLevelUpBoard = jest.fn();
     mockResetAfterLevelUp = jest.fn();
@@ -58,6 +60,7 @@ describe("runLevelUpAnimation", () => {
       mockScaredTimer,
       mockCtx,
       mockBoundaries,
+      mockAudioPlayer,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
       mockResetAfterLevelUp
@@ -75,7 +78,8 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockBoundaries
+      mockBoundaries,
+      mockAudioPlayer
     );
   });
 
@@ -90,6 +94,7 @@ describe("runLevelUpAnimation", () => {
       mockScaredTimer,
       mockCtx,
       mockBoundaries,
+      mockAudioPlayer,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
       mockResetAfterLevelUp
@@ -111,6 +116,7 @@ describe("runLevelUpAnimation", () => {
       mockScaredTimer,
       mockCtx,
       mockBoundaries,
+      mockAudioPlayer,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
       mockResetAfterLevelUp
@@ -131,6 +137,7 @@ describe("runLevelUpAnimation", () => {
       mockScaredTimer,
       mockCtx,
       mockBoundaries,
+      mockAudioPlayer,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
       mockResetAfterLevelUp
@@ -149,6 +156,7 @@ describe("runLevelUpAnimation", () => {
       mockScaredTimer,
       mockCtx,
       mockBoundaries,
+      mockAudioPlayer,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
       mockResetAfterLevelUp
@@ -168,6 +176,7 @@ describe("runLevelUpAnimation", () => {
       mockScaredTimer,
       mockCtx,
       mockBoundaries,
+      mockAudioPlayer,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
       mockResetAfterLevelUp
@@ -188,6 +197,7 @@ describe("runLevelUpAnimation", () => {
       mockScaredTimer,
       mockCtx,
       mockBoundaries,
+      mockAudioPlayer,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
       mockResetAfterLevelUp
@@ -210,6 +220,7 @@ describe("runLevelUpAnimation", () => {
       mockScaredTimer,
       mockCtx,
       mockBoundaries,
+      mockAudioPlayer,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
       mockResetAfterLevelUp
@@ -229,6 +240,7 @@ describe("runLevelUpAnimation", () => {
       mockScaredTimer,
       mockCtx,
       mockBoundaries,
+      mockAudioPlayer,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
       mockResetAfterLevelUp
@@ -241,7 +253,8 @@ describe("runLevelUpAnimation", () => {
       mockPellets,
       mockPowerUps,
       mockCycleTimer,
-      mockScaredTimer
+      mockScaredTimer,
+      mockAudioPlayer
     );
   });
 });

--- a/client/src/components/game/mechanics/pellets/levelUpAnimation/runLevelUpAnimation.test.js
+++ b/client/src/components/game/mechanics/pellets/levelUpAnimation/runLevelUpAnimation.test.js
@@ -10,7 +10,6 @@ let mockPowerUps;
 let mockCycleTimer;
 let mockScaredTimer;
 let mockCtx;
-let mockAudioPlayer;
 let mockBoundary;
 let mockBoundaries;
 let mockRunLevelUpAnimation;
@@ -38,9 +37,6 @@ describe("runLevelUpAnimation", () => {
       textAlign: undefined,
       fillText: () => undefined,
     };
-    mockAudioPlayer = {
-      unloadLevelUp: () => undefined,
-    };
     mockBoundary = {
       flash: () => undefined,
     };
@@ -61,7 +57,6 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
@@ -80,7 +75,6 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries
     );
   });
@@ -95,7 +89,6 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
@@ -117,7 +110,6 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
@@ -138,7 +130,6 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
@@ -157,7 +148,6 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
@@ -177,7 +167,6 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
@@ -198,7 +187,6 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
@@ -208,27 +196,6 @@ describe("runLevelUpAnimation", () => {
     expect(cancelAnimationFrame).toHaveBeenCalledWith(
       mockVariables.animationId
     );
-  });
-
-  it("calls unloadLevelUp on the audioPlayer when the level up count reaches 350", () => {
-    mockVariables.levelUpCount = 350;
-    jest.spyOn(mockAudioPlayer, "unloadLevelUp");
-    runLevelUpAnimation(
-      mockVariables,
-      mockPacman,
-      mockGhosts,
-      mockPellets,
-      mockPowerUps,
-      mockCycleTimer,
-      mockScaredTimer,
-      mockCtx,
-      mockAudioPlayer,
-      mockBoundaries,
-      mockRunLevelUpAnimation,
-      mockDrawLevelUpBoard,
-      mockResetAfterLevelUp
-    );
-    expect(mockAudioPlayer.unloadLevelUp).toHaveBeenCalledTimes(1);
   });
 
   it("increases the level by 1 when the level up count reaches 350", () => {
@@ -242,7 +209,6 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
@@ -262,7 +228,6 @@ describe("runLevelUpAnimation", () => {
       mockCycleTimer,
       mockScaredTimer,
       mockCtx,
-      mockAudioPlayer,
       mockBoundaries,
       mockRunLevelUpAnimation,
       mockDrawLevelUpBoard,
@@ -276,8 +241,7 @@ describe("runLevelUpAnimation", () => {
       mockPellets,
       mockPowerUps,
       mockCycleTimer,
-      mockScaredTimer,
-      mockAudioPlayer
+      mockScaredTimer
     );
   });
 });

--- a/client/src/components/game/models/audioPlayer.js
+++ b/client/src/components/game/models/audioPlayer.js
@@ -29,6 +29,7 @@ export default class AudioPlayer {
     this.ghostSiren = ghostSiren;
     this.ghostScared = ghostScared;
     this.ghostRetreating = ghostRetreating;
+    this.ghostAudioWantsToPlay = false;
     this.pacmanDeath = pacmanDeath;
     this.pacmanDeath.wantsToPlay = false;
     this.levelUp = levelUp;
@@ -53,10 +54,9 @@ export default class AudioPlayer {
     this.ghostRetreating.play();
   }
 
-  pauseGhostAudio() {
-    this.ghostSiren.pause();
-    this.ghostScared.pause();
-    this.ghostRetreating.pause();
+  stopGhostAudio() {
+    this.#pauseGhostAudio();
+    this.ghostAudioWantsToPlay = false;
   }
 
   playPacmanDeath() {
@@ -75,8 +75,16 @@ export default class AudioPlayer {
   }
 
   pauseAll() {
-    this.pauseGhostAudio();
+    this.#pauseGhostAudio();
     this.pacmanDeath.pause();
     this.levelUp.pause();
+  }
+
+  // private
+
+  #pauseGhostAudio() {
+    this.ghostSiren.pause();
+    this.ghostScared.pause();
+    this.ghostRetreating.pause();
   }
 }

--- a/client/src/components/game/models/audioPlayer.js
+++ b/client/src/components/game/models/audioPlayer.js
@@ -27,6 +27,9 @@ export default class AudioPlayer {
     levelUp = new Howl({
       src: "./audio/level_up.wav",
       volume: 0.2,
+      onend: () => {
+        levelUp.wantsToPlay = false;
+      },
     })
   ) {
     this.ghostSiren = ghostSiren;

--- a/client/src/components/game/models/audioPlayer.js
+++ b/client/src/components/game/models/audioPlayer.js
@@ -27,10 +27,15 @@ export default class AudioPlayer {
     })
   ) {
     this.ghostSiren = ghostSiren;
+    this.ghostSiren.wantsToPlay = false;
     this.ghostScared = ghostScared;
+    this.ghostScared.wantsToPlay = false;
     this.ghostRetreating = ghostRetreating;
+    this.ghostRetreating.wantsToPlay = false;
     this.pacmanDeath = pacmanDeath;
+    this.pacmanDeath.wantsToPlay = false;
     this.levelUp = levelUp;
+    this.levelUp.wantsToPlay = false;
   }
 
   loadGhost() {

--- a/client/src/components/game/models/audioPlayer.js
+++ b/client/src/components/game/models/audioPlayer.js
@@ -53,6 +53,12 @@ export default class AudioPlayer {
     this.ghostRetreating.play();
   }
 
+  pauseGhostAudio() {
+    this.ghostSiren.pause();
+    this.ghostScared.pause();
+    this.ghostRetreating.pause();
+  }
+
   playPacmanDeath() {
     this.pacmanDeath.play();
     this.pacmanDeath.wantsToPlay = true;
@@ -69,9 +75,7 @@ export default class AudioPlayer {
   }
 
   pauseAll() {
-    this.ghostSiren.pause();
-    this.ghostScared.pause();
-    this.ghostRetreating.pause();
+    this.pauseGhostAudio();
     this.pacmanDeath.pause();
     this.levelUp.pause();
   }

--- a/client/src/components/game/models/audioPlayer.js
+++ b/client/src/components/game/models/audioPlayer.js
@@ -52,8 +52,11 @@ export default class AudioPlayer {
 
   playGhostSiren() {
     this.ghostScared.pause();
+    this.ghostScared.wantsToPlay = false;
     this.ghostRetreating.pause();
+    this.ghostRetreating.wantsToPlay = false;
     this.ghostSiren.play();
+    this.ghostSiren.wantsToPlay = true;
   }
 
   playGhostScared() {

--- a/client/src/components/game/models/audioPlayer.js
+++ b/client/src/components/game/models/audioPlayer.js
@@ -20,6 +20,9 @@ export default class AudioPlayer {
     pacmanDeath = new Howl({
       src: "./audio/pacman_death.wav",
       volume: 0.3,
+      onend: () => {
+        pacmanDeath.wantsToPlay = false;
+      },
     }),
     levelUp = new Howl({
       src: "./audio/level_up.wav",

--- a/client/src/components/game/models/audioPlayer.js
+++ b/client/src/components/game/models/audioPlayer.js
@@ -61,8 +61,11 @@ export default class AudioPlayer {
 
   playGhostScared() {
     this.ghostSiren.pause();
+    this.ghostSiren.wantsToPlay = false;
     this.ghostRetreating.pause();
+    this.ghostRetreating.wantsToPlay = false;
     this.ghostScared.play();
+    this.ghostScared.wantsToPlay = true;
   }
 
   playGhostRetreating() {

--- a/client/src/components/game/models/audioPlayer.js
+++ b/client/src/components/game/models/audioPlayer.js
@@ -70,8 +70,11 @@ export default class AudioPlayer {
 
   playGhostRetreating() {
     this.ghostSiren.pause();
+    this.ghostSiren.wantsToPlay = false;
     this.ghostScared.pause();
+    this.ghostScared.wantsToPlay = false;
     this.ghostRetreating.play();
+    this.ghostRetreating.wantsToPlay = true;
   }
 
   loadAndPlayPacmanDeath() {

--- a/client/src/components/game/models/audioPlayer.js
+++ b/client/src/components/game/models/audioPlayer.js
@@ -27,77 +27,45 @@ export default class AudioPlayer {
     })
   ) {
     this.ghostSiren = ghostSiren;
-    this.ghostSiren.wantsToPlay = false;
     this.ghostScared = ghostScared;
-    this.ghostScared.wantsToPlay = false;
     this.ghostRetreating = ghostRetreating;
-    this.ghostRetreating.wantsToPlay = false;
     this.pacmanDeath = pacmanDeath;
     this.pacmanDeath.wantsToPlay = false;
     this.levelUp = levelUp;
     this.levelUp.wantsToPlay = false;
   }
 
-  loadGhost() {
-    this.ghostSiren.load();
-    this.ghostScared.load();
-    this.ghostRetreating.load();
-  }
-
-  unloadGhost() {
-    this.ghostSiren.unload();
-    this.ghostScared.unload();
-    this.ghostRetreating.unload();
-  }
-
   playGhostSiren() {
     this.ghostScared.pause();
-    this.ghostScared.wantsToPlay = false;
     this.ghostRetreating.pause();
-    this.ghostRetreating.wantsToPlay = false;
     this.ghostSiren.play();
-    this.ghostSiren.wantsToPlay = true;
   }
 
   playGhostScared() {
     this.ghostSiren.pause();
-    this.ghostSiren.wantsToPlay = false;
     this.ghostRetreating.pause();
-    this.ghostRetreating.wantsToPlay = false;
     this.ghostScared.play();
-    this.ghostScared.wantsToPlay = true;
   }
 
   playGhostRetreating() {
     this.ghostSiren.pause();
-    this.ghostSiren.wantsToPlay = false;
     this.ghostScared.pause();
-    this.ghostScared.wantsToPlay = false;
     this.ghostRetreating.play();
-    this.ghostRetreating.wantsToPlay = true;
   }
 
-  loadAndPlayPacmanDeath() {
-    this.pacmanDeath.load();
-    this.#playPacmanDeath();
+  playPacmanDeath() {
+    this.pacmanDeath.play();
+    this.pacmanDeath.wantsToPlay = true;
   }
 
-  unloadPacmanDeath() {
-    this.pacmanDeath.unload();
+  playLevelUp() {
+    this.levelUp.play();
+    this.levelUp.wantsToPlay = true;
   }
 
-  loadAndPlayLevelUp() {
-    this.levelUp.load();
-    this.#playLevelUp();
-  }
-
-  unloadLevelUp() {
-    this.levelUp.unload();
-  }
-
-  playPacmanDeathAndLevelUpIfLoaded() {
-    if (this.pacmanDeath._state === "loaded") this.#playPacmanDeath();
-    if (this.levelUp._state === "loaded") this.#playLevelUp();
+  playPacmanDeathAndLevelUpIfWantTo() {
+    if (this.pacmanDeath.wantsToPlay === true) this.pacmanDeath.play();
+    if (this.levelUp.wantsToPlay === true) this.levelUp.play();
   }
 
   pauseAll() {
@@ -106,15 +74,5 @@ export default class AudioPlayer {
     this.ghostRetreating.pause();
     this.pacmanDeath.pause();
     this.levelUp.pause();
-  }
-
-  // private
-
-  #playPacmanDeath() {
-    this.pacmanDeath.play();
-  }
-
-  #playLevelUp() {
-    this.levelUp.play();
   }
 }

--- a/client/src/components/game/models/audioPlayer.test.js
+++ b/client/src/components/game/models/audioPlayer.test.js
@@ -142,9 +142,20 @@ describe("AudioPlayer", () => {
   });
 
   describe("playGhostSiren", () => {
+    beforeEach(() => {
+      mockGhostScared.wantsToPlay = true;
+      mockGhostRetreating.wantsToPlay = true;
+      mockGhostSiren.wantsToPlay = false;
+    });
+
     it("calls pause on the ghostScared", () => {
       audioPlayer.playGhostSiren();
       expect(mockGhostScared.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets wantsToPlay on ghostScared to false", () => {
+      audioPlayer.playGhostSiren();
+      expect(mockGhostScared.wantsToPlay).toBe(false);
     });
 
     it("calls pause on the ghostRetreating", () => {
@@ -152,10 +163,20 @@ describe("AudioPlayer", () => {
       expect(mockGhostRetreating.pause).toHaveBeenCalledTimes(1);
     });
 
+    it("sets wantsToPlay on ghostRetreating to false", () => {
+      audioPlayer.playGhostSiren();
+      expect(mockGhostRetreating.wantsToPlay).toBe(false);
+    });
+
     it("calls play on the ghostSiren", () => {
       jest.spyOn(mockGhostSiren, "play");
       audioPlayer.playGhostSiren();
       expect(mockGhostSiren.play).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets wantsToPlay on ghostScared to true", () => {
+      audioPlayer.playGhostSiren();
+      expect(mockGhostSiren.wantsToPlay).toBe(true);
     });
   });
 

--- a/client/src/components/game/models/audioPlayer.test.js
+++ b/client/src/components/game/models/audioPlayer.test.js
@@ -174,16 +174,27 @@ describe("AudioPlayer", () => {
       expect(mockGhostSiren.play).toHaveBeenCalledTimes(1);
     });
 
-    it("sets wantsToPlay on ghostScared to true", () => {
+    it("sets wantsToPlay on ghostSiren to true", () => {
       audioPlayer.playGhostSiren();
       expect(mockGhostSiren.wantsToPlay).toBe(true);
     });
   });
 
   describe("playGhostScared", () => {
+    beforeEach(() => {
+      mockGhostSiren.wantsToPlay = true;
+      mockGhostRetreating.wantsToPlay = true;
+      mockGhostScared.wantsToPlay = false;
+    });
+
     it("calls pause on the ghostSiren", () => {
       audioPlayer.playGhostScared();
       expect(mockGhostSiren.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets wantsToPlay on ghostSiren to false", () => {
+      audioPlayer.playGhostScared();
+      expect(mockGhostSiren.wantsToPlay).toBe(false);
     });
 
     it("calls pause on the ghostRetreating", () => {
@@ -191,10 +202,20 @@ describe("AudioPlayer", () => {
       expect(mockGhostRetreating.pause).toHaveBeenCalledTimes(1);
     });
 
+    it("sets wantsToPlay on ghostRetreating to false", () => {
+      audioPlayer.playGhostScared();
+      expect(mockGhostRetreating.wantsToPlay).toBe(false);
+    });
+
     it("calls play on the ghostScared", () => {
       jest.spyOn(mockGhostScared, "play");
       audioPlayer.playGhostScared();
       expect(mockGhostScared.play).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets wantsToPlay on ghostScared to true", () => {
+      audioPlayer.playGhostScared();
+      expect(mockGhostScared.wantsToPlay).toBe(true);
     });
   });
 

--- a/client/src/components/game/models/audioPlayer.test.js
+++ b/client/src/components/game/models/audioPlayer.test.js
@@ -133,7 +133,24 @@ describe("AudioPlayer", () => {
     });
   });
 
-  describe("PlayPacmanDeath", () => {
+  describe("pauseGhostAudio", () => {
+    it("calls pause on ghostSiren", () => {
+      audioPlayer.pauseGhostAudio();
+      expect(mockGhostSiren.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls pause on ghostScared", () => {
+      audioPlayer.pauseGhostAudio();
+      expect(mockGhostScared.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls pause on ghostRetreating", () => {
+      audioPlayer.pauseGhostAudio();
+      expect(mockGhostRetreating.pause).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("playPacmanDeath", () => {
     it("calls play on pacmanDeath", () => {
       audioPlayer.playPacmanDeath();
       expect(mockPacmanDeath.play).toHaveBeenCalledTimes(1);
@@ -182,19 +199,10 @@ describe("AudioPlayer", () => {
   });
 
   describe("pauseAll", () => {
-    it("calls pause on the ghostSiren", () => {
+    it("calls pauseGhostAudio", () => {
+      jest.spyOn(audioPlayer, "pauseGhostAudio");
       audioPlayer.pauseAll();
-      expect(mockGhostSiren.pause).toHaveBeenCalledTimes(1);
-    });
-
-    it("calls pause on the ghostScared", () => {
-      audioPlayer.pauseAll();
-      expect(mockGhostScared.pause).toHaveBeenCalledTimes(1);
-    });
-
-    it("calls pause on the ghostRetreating", () => {
-      audioPlayer.pauseAll();
-      expect(mockGhostRetreating.pause).toHaveBeenCalledTimes(1);
+      expect(audioPlayer.pauseGhostAudio).toHaveBeenCalledTimes(1);
     });
 
     it("calls pause on the pacmanDeath", () => {

--- a/client/src/components/game/models/audioPlayer.test.js
+++ b/client/src/components/game/models/audioPlayer.test.js
@@ -220,9 +220,20 @@ describe("AudioPlayer", () => {
   });
 
   describe("playGhostRetreating", () => {
+    beforeEach(() => {
+      mockGhostSiren.wantsToPlay = true;
+      mockGhostScared.wantsToPlay = true;
+      mockGhostRetreating.wantsToPlay = false;
+    });
+
     it("calls pause on the ghostSiren", () => {
       audioPlayer.playGhostRetreating();
       expect(mockGhostSiren.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets wantsToPlay on ghostSiren to false", () => {
+      audioPlayer.playGhostRetreating();
+      expect(mockGhostSiren.wantsToPlay).toBe(false);
     });
 
     it("calls pause on the ghostScared", () => {
@@ -230,10 +241,20 @@ describe("AudioPlayer", () => {
       expect(mockGhostScared.pause).toHaveBeenCalledTimes(1);
     });
 
+    it("sets wantsToPlay on ghostScared to false", () => {
+      audioPlayer.playGhostRetreating();
+      expect(mockGhostScared.wantsToPlay).toBe(false);
+    });
+
     it("calls play on the ghostRetreating", () => {
       jest.spyOn(mockGhostRetreating, "play");
       audioPlayer.playGhostRetreating();
       expect(mockGhostRetreating.play).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets wantsToPlay on ghostRetreating to true", () => {
+      audioPlayer.playGhostRetreating();
+      expect(mockGhostRetreating.wantsToPlay).toBe(true);
     });
   });
 

--- a/client/src/components/game/models/audioPlayer.test.js
+++ b/client/src/components/game/models/audioPlayer.test.js
@@ -4,9 +4,7 @@ let mockGhostSiren;
 let mockGhostScared;
 let mockGhostRetreating;
 let mockPacmanDeath;
-let mockUnloadedPacmanDeath;
 let mockLevelUp;
-let mockUnloadedLevelUp;
 let audioPlayer;
 
 describe("AudioPlayer", () => {
@@ -37,16 +35,6 @@ describe("AudioPlayer", () => {
     };
     mockPacmanDeath = {
       name: "pacmanDeath",
-      _state: "loaded",
-      load: () => undefined,
-      unload: () => undefined,
-      pause: () => undefined,
-      play: () => undefined,
-      wantsToPlay: undefined,
-    };
-    mockUnloadedPacmanDeath = {
-      name: "unloadedPacmanDeath",
-      _state: "unloaded",
       load: () => undefined,
       unload: () => undefined,
       pause: () => undefined,
@@ -55,16 +43,6 @@ describe("AudioPlayer", () => {
     };
     mockLevelUp = {
       name: "levelUp",
-      _state: "loaded",
-      load: () => undefined,
-      unload: () => undefined,
-      pause: () => undefined,
-      play: () => undefined,
-      wantsToPlay: undefined,
-    };
-    mockUnloadedLevelUp = {
-      name: "unloadedLevelUp",
-      _state: "unloaded",
       load: () => undefined,
       unload: () => undefined,
       pause: () => undefined,
@@ -93,79 +71,23 @@ describe("AudioPlayer", () => {
     expect(audioPlayer.levelUp).toEqual(mockLevelUp);
   });
 
-  it("sets wantsToPlay on each audio object to false", () => {
-    expect(audioPlayer.ghostSiren.wantsToPlay).toBe(false);
-    expect(audioPlayer.ghostScared.wantsToPlay).toBe(false);
-    expect(audioPlayer.ghostRetreating.wantsToPlay).toBe(false);
-    expect(audioPlayer.pacmanDeath.wantsToPlay).toBe(false);
-    expect(audioPlayer.levelUp.wantsToPlay).toBe(false);
+  it("sets wantsToPlay on pacmanDeath to false", () => {
+    expect(mockPacmanDeath.wantsToPlay).toBe(false);
   });
 
-  describe("loadGhost", () => {
-    it("calls load on the ghostSiren", () => {
-      jest.spyOn(mockGhostSiren, "load");
-      audioPlayer.loadGhost();
-      expect(mockGhostSiren.load).toHaveBeenCalledTimes(1);
-    });
-
-    it("calls load on the ghostScared", () => {
-      jest.spyOn(mockGhostScared, "load");
-      audioPlayer.loadGhost();
-      expect(mockGhostScared.load).toHaveBeenCalledTimes(1);
-    });
-
-    it("calls load on the ghostRetreating", () => {
-      jest.spyOn(mockGhostRetreating, "load");
-      audioPlayer.loadGhost();
-      expect(mockGhostRetreating.load).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("unloadGhost", () => {
-    it("calls unload on the ghostSiren", () => {
-      jest.spyOn(mockGhostSiren, "unload");
-      audioPlayer.unloadGhost();
-      expect(mockGhostSiren.unload).toHaveBeenCalledTimes(1);
-    });
-
-    it("calls unload on the ghostScared", () => {
-      jest.spyOn(mockGhostScared, "unload");
-      audioPlayer.unloadGhost();
-      expect(mockGhostScared.unload).toHaveBeenCalledTimes(1);
-    });
-
-    it("calls unload on the ghostRetreating", () => {
-      jest.spyOn(mockGhostRetreating, "unload");
-      audioPlayer.unloadGhost();
-      expect(mockGhostRetreating.unload).toHaveBeenCalledTimes(1);
-    });
+  it("sets wantsToPlay on levelUp to false", () => {
+    expect(mockLevelUp.wantsToPlay).toBe(false);
   });
 
   describe("playGhostSiren", () => {
-    beforeEach(() => {
-      mockGhostScared.wantsToPlay = true;
-      mockGhostRetreating.wantsToPlay = true;
-      mockGhostSiren.wantsToPlay = false;
-    });
-
     it("calls pause on the ghostScared", () => {
       audioPlayer.playGhostSiren();
       expect(mockGhostScared.pause).toHaveBeenCalledTimes(1);
     });
 
-    it("sets wantsToPlay on ghostScared to false", () => {
-      audioPlayer.playGhostSiren();
-      expect(mockGhostScared.wantsToPlay).toBe(false);
-    });
-
     it("calls pause on the ghostRetreating", () => {
       audioPlayer.playGhostSiren();
       expect(mockGhostRetreating.pause).toHaveBeenCalledTimes(1);
-    });
-
-    it("sets wantsToPlay on ghostRetreating to false", () => {
-      audioPlayer.playGhostSiren();
-      expect(mockGhostRetreating.wantsToPlay).toBe(false);
     });
 
     it("calls play on the ghostSiren", () => {
@@ -173,28 +95,12 @@ describe("AudioPlayer", () => {
       audioPlayer.playGhostSiren();
       expect(mockGhostSiren.play).toHaveBeenCalledTimes(1);
     });
-
-    it("sets wantsToPlay on ghostSiren to true", () => {
-      audioPlayer.playGhostSiren();
-      expect(mockGhostSiren.wantsToPlay).toBe(true);
-    });
   });
 
   describe("playGhostScared", () => {
-    beforeEach(() => {
-      mockGhostSiren.wantsToPlay = true;
-      mockGhostRetreating.wantsToPlay = true;
-      mockGhostScared.wantsToPlay = false;
-    });
-
     it("calls pause on the ghostSiren", () => {
       audioPlayer.playGhostScared();
       expect(mockGhostSiren.pause).toHaveBeenCalledTimes(1);
-    });
-
-    it("sets wantsToPlay on ghostSiren to false", () => {
-      audioPlayer.playGhostScared();
-      expect(mockGhostSiren.wantsToPlay).toBe(false);
     });
 
     it("calls pause on the ghostRetreating", () => {
@@ -202,38 +108,17 @@ describe("AudioPlayer", () => {
       expect(mockGhostRetreating.pause).toHaveBeenCalledTimes(1);
     });
 
-    it("sets wantsToPlay on ghostRetreating to false", () => {
-      audioPlayer.playGhostScared();
-      expect(mockGhostRetreating.wantsToPlay).toBe(false);
-    });
-
     it("calls play on the ghostScared", () => {
       jest.spyOn(mockGhostScared, "play");
       audioPlayer.playGhostScared();
       expect(mockGhostScared.play).toHaveBeenCalledTimes(1);
     });
-
-    it("sets wantsToPlay on ghostScared to true", () => {
-      audioPlayer.playGhostScared();
-      expect(mockGhostScared.wantsToPlay).toBe(true);
-    });
   });
 
   describe("playGhostRetreating", () => {
-    beforeEach(() => {
-      mockGhostSiren.wantsToPlay = true;
-      mockGhostScared.wantsToPlay = true;
-      mockGhostRetreating.wantsToPlay = false;
-    });
-
     it("calls pause on the ghostSiren", () => {
       audioPlayer.playGhostRetreating();
       expect(mockGhostSiren.pause).toHaveBeenCalledTimes(1);
-    });
-
-    it("sets wantsToPlay on ghostSiren to false", () => {
-      audioPlayer.playGhostRetreating();
-      expect(mockGhostSiren.wantsToPlay).toBe(false);
     });
 
     it("calls pause on the ghostScared", () => {
@@ -241,88 +126,58 @@ describe("AudioPlayer", () => {
       expect(mockGhostScared.pause).toHaveBeenCalledTimes(1);
     });
 
-    it("sets wantsToPlay on ghostScared to false", () => {
-      audioPlayer.playGhostRetreating();
-      expect(mockGhostScared.wantsToPlay).toBe(false);
-    });
-
     it("calls play on the ghostRetreating", () => {
       jest.spyOn(mockGhostRetreating, "play");
       audioPlayer.playGhostRetreating();
       expect(mockGhostRetreating.play).toHaveBeenCalledTimes(1);
     });
-
-    it("sets wantsToPlay on ghostRetreating to true", () => {
-      audioPlayer.playGhostRetreating();
-      expect(mockGhostRetreating.wantsToPlay).toBe(true);
-    });
   });
 
-  describe("loadAndPlayPacmanDeath", () => {
-    it("calls load on pacmanDeath", () => {
-      jest.spyOn(mockPacmanDeath, "load");
-      audioPlayer.loadAndPlayPacmanDeath();
-      expect(mockPacmanDeath.load).toHaveBeenCalledTimes(1);
-    });
-
+  describe("PlayPacmanDeath", () => {
     it("calls play on pacmanDeath", () => {
-      audioPlayer.loadAndPlayPacmanDeath();
+      audioPlayer.playPacmanDeath();
       expect(mockPacmanDeath.play).toHaveBeenCalledTimes(1);
     });
-  });
 
-  describe("unloadPacmanDeath", () => {
-    it("calls unload on pacmanDeath", () => {
-      jest.spyOn(mockPacmanDeath, "unload");
-      audioPlayer.unloadPacmanDeath();
-      expect(mockPacmanDeath.unload).toHaveBeenCalledTimes(1);
+    it("sets wantsToPlay on pacmanDeath to true", () => {
+      audioPlayer.playPacmanDeath();
+      expect(mockPacmanDeath.wantsToPlay).toBe(true);
     });
   });
 
-  describe("loadAndPlayLevelUp", () => {
-    it("calls load on levelUp", () => {
-      jest.spyOn(mockLevelUp, "load");
-      audioPlayer.loadAndPlayLevelUp();
-      expect(mockLevelUp.load).toHaveBeenCalledTimes(1);
-    });
-
+  describe("playLevelUp", () => {
     it("calls play on levelUp", () => {
-      audioPlayer.loadAndPlayLevelUp();
+      audioPlayer.playLevelUp();
       expect(mockLevelUp.play).toHaveBeenCalledTimes(1);
     });
-  });
 
-  describe("unloadLevelUp", () => {
-    it("calls unload on levelUp", () => {
-      jest.spyOn(mockLevelUp, "unload");
-      audioPlayer.unloadLevelUp();
-      expect(mockLevelUp.unload).toHaveBeenCalledTimes(1);
+    it("sets wantsToPlay on levelUp to true", () => {
+      audioPlayer.playLevelUp();
+      expect(mockLevelUp.wantsToPlay).toBe(true);
     });
   });
 
-  describe("playPacmanDeathAndLevelUpIfLoaded", () => {
-    it("calls play on pacmanDeath if its state is loaded", () => {
-      audioPlayer.playPacmanDeathAndLevelUpIfLoaded();
+  describe("playPacmanDeathAndLevelUpIfWantTo", () => {
+    it("calls play on pacmanDeath if wantsToPlay is true", () => {
+      mockPacmanDeath.wantsToPlay = true;
+      audioPlayer.playPacmanDeathAndLevelUpIfWantTo();
       expect(mockPacmanDeath.play).toHaveBeenCalledTimes(1);
     });
 
-    it("does not call play on pacmanDeath if its state is unloaded", () => {
-      audioPlayer.pacmanDeath = mockUnloadedPacmanDeath;
-      jest.spyOn(mockUnloadedPacmanDeath, "play");
-      audioPlayer.playPacmanDeathAndLevelUpIfLoaded();
-      expect(mockUnloadedPacmanDeath.play).toHaveBeenCalledTimes(0);
+    it("does not call play on pacmanDeath if wantsToPlay is false", () => {
+      audioPlayer.playPacmanDeathAndLevelUpIfWantTo();
+      expect(mockPacmanDeath.play).toHaveBeenCalledTimes(0);
     });
 
-    it("calls play on levelUp if its state is unloaded", () => {
-      audioPlayer.playPacmanDeathAndLevelUpIfLoaded();
+    it("calls play on levelUp if wantsToPlay is true", () => {
+      mockLevelUp.wantsToPlay = true;
+      audioPlayer.playPacmanDeathAndLevelUpIfWantTo();
       expect(mockLevelUp.play).toHaveBeenCalledTimes(1);
     });
 
-    it("does not call play on levelUp if its state is unloaded", () => {
-      audioPlayer.levelUp = mockUnloadedLevelUp;
-      jest.spyOn(mockUnloadedLevelUp, "play");
-      audioPlayer.playPacmanDeathAndLevelUpIfLoaded();
-      expect(mockUnloadedLevelUp.play).toHaveBeenCalledTimes(0);
+    it("does not call play on levelUp if wantsToPlay is false", () => {
+      audioPlayer.playPacmanDeathAndLevelUpIfWantTo();
+      expect(mockLevelUp.play).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/client/src/components/game/models/audioPlayer.test.js
+++ b/client/src/components/game/models/audioPlayer.test.js
@@ -71,6 +71,10 @@ describe("AudioPlayer", () => {
     expect(audioPlayer.levelUp).toEqual(mockLevelUp);
   });
 
+  it("sets ghostAudioWantsToPlay to false", () => {
+    expect(audioPlayer.ghostAudioWantsToPlay).toBe(false);
+  });
+
   it("sets wantsToPlay on pacmanDeath to false", () => {
     expect(mockPacmanDeath.wantsToPlay).toBe(false);
   });
@@ -133,20 +137,26 @@ describe("AudioPlayer", () => {
     });
   });
 
-  describe("pauseGhostAudio", () => {
+  describe("stopGhostAudio", () => {
     it("calls pause on ghostSiren", () => {
-      audioPlayer.pauseGhostAudio();
+      audioPlayer.stopGhostAudio();
       expect(mockGhostSiren.pause).toHaveBeenCalledTimes(1);
     });
 
     it("calls pause on ghostScared", () => {
-      audioPlayer.pauseGhostAudio();
+      audioPlayer.stopGhostAudio();
       expect(mockGhostScared.pause).toHaveBeenCalledTimes(1);
     });
 
     it("calls pause on ghostRetreating", () => {
-      audioPlayer.pauseGhostAudio();
+      audioPlayer.stopGhostAudio();
       expect(mockGhostRetreating.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets ghostAudioWantsToPlay to false", () => {
+      audioPlayer.ghostAudioWantsToPlay = true;
+      audioPlayer.stopGhostAudio();
+      expect(audioPlayer.ghostAudioWantsToPlay).toBe(false);
     });
   });
 
@@ -199,10 +209,19 @@ describe("AudioPlayer", () => {
   });
 
   describe("pauseAll", () => {
-    it("calls pauseGhostAudio", () => {
-      jest.spyOn(audioPlayer, "pauseGhostAudio");
+    it("calls pause on ghostSiren", () => {
       audioPlayer.pauseAll();
-      expect(audioPlayer.pauseGhostAudio).toHaveBeenCalledTimes(1);
+      expect(mockGhostSiren.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls pause on ghostScared", () => {
+      audioPlayer.pauseAll();
+      expect(mockGhostScared.pause).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls pause on ghostRetreating", () => {
+      audioPlayer.pauseAll();
+      expect(mockGhostRetreating.pause).toHaveBeenCalledTimes(1);
     });
 
     it("calls pause on the pacmanDeath", () => {

--- a/client/src/components/game/models/audioPlayer.test.js
+++ b/client/src/components/game/models/audioPlayer.test.js
@@ -17,6 +17,7 @@ describe("AudioPlayer", () => {
       unload: () => undefined,
       pause: () => undefined,
       play: () => undefined,
+      wantsToPlay: undefined,
     };
     mockGhostScared = {
       name: "scared",
@@ -24,6 +25,7 @@ describe("AudioPlayer", () => {
       unload: () => undefined,
       pause: () => undefined,
       play: () => undefined,
+      wantsToPlay: undefined,
     };
     mockGhostRetreating = {
       name: "retreating",
@@ -31,6 +33,7 @@ describe("AudioPlayer", () => {
       unload: () => undefined,
       pause: () => undefined,
       play: () => undefined,
+      wantsToPlay: undefined,
     };
     mockPacmanDeath = {
       name: "pacmanDeath",
@@ -39,6 +42,7 @@ describe("AudioPlayer", () => {
       unload: () => undefined,
       pause: () => undefined,
       play: () => undefined,
+      wantsToPlay: undefined,
     };
     mockUnloadedPacmanDeath = {
       name: "unloadedPacmanDeath",
@@ -47,6 +51,7 @@ describe("AudioPlayer", () => {
       unload: () => undefined,
       pause: () => undefined,
       play: () => undefined,
+      wantsToPlay: undefined,
     };
     mockLevelUp = {
       name: "levelUp",
@@ -55,6 +60,7 @@ describe("AudioPlayer", () => {
       unload: () => undefined,
       pause: () => undefined,
       play: () => undefined,
+      wantsToPlay: undefined,
     };
     mockUnloadedLevelUp = {
       name: "unloadedLevelUp",
@@ -63,6 +69,7 @@ describe("AudioPlayer", () => {
       unload: () => undefined,
       pause: () => undefined,
       play: () => undefined,
+      wantsToPlay: undefined,
     };
     audioPlayer = new AudioPlayer(
       mockGhostSiren,
@@ -84,6 +91,14 @@ describe("AudioPlayer", () => {
     expect(audioPlayer.ghostRetreating).toEqual(mockGhostRetreating);
     expect(audioPlayer.pacmanDeath).toEqual(mockPacmanDeath);
     expect(audioPlayer.levelUp).toEqual(mockLevelUp);
+  });
+
+  it("sets wantsToPlay on each audio object to false", () => {
+    expect(audioPlayer.ghostSiren.wantsToPlay).toBe(false);
+    expect(audioPlayer.ghostScared.wantsToPlay).toBe(false);
+    expect(audioPlayer.ghostRetreating.wantsToPlay).toBe(false);
+    expect(audioPlayer.pacmanDeath.wantsToPlay).toBe(false);
+    expect(audioPlayer.levelUp.wantsToPlay).toBe(false);
   });
 
   describe("loadGhost", () => {


### PR DESCRIPTION
Create a new variable in the AudioPlayer called wantsToPlay for each set of audio objects. Instead of loading and unloading the audio files, change this variable to true or false and only play the audio file if this variable is true for that specific audio object. 

This should remove the delay that often occurs between sounds on the live site, and also maintain all audio objects when internet connection is lost.